### PR TITLE
flatten structure of 'pytools' module, eliminating 'common' sub-package

### DIFF
--- a/src/facet/_facet.py
+++ b/src/facet/_facet.py
@@ -7,7 +7,7 @@ from typing import *
 
 import pandas as pd
 
-from pytools.common import is_list_like
+from pytools.api import is_list_like
 
 
 class Sample:

--- a/src/facet/crossfit/_crossfit.py
+++ b/src/facet/crossfit/_crossfit.py
@@ -15,9 +15,9 @@ from sklearn.model_selection import BaseCrossValidator
 from sklearn.utils import check_random_state
 
 from facet import Sample
-from pytools.common import inheritdoc
-from pytools.common.fit import FittableMixin
-from pytools.common.parallelization import ParallelizableMixin
+from pytools.api import inheritdoc
+from pytools.fit import FittableMixin
+from pytools.parallelization import ParallelizableMixin
 from sklearndf import LearnerDF, TransformerDF
 from sklearndf.pipeline import (
     ClassifierPipelineDF,

--- a/src/facet/inspection/_explainer.py
+++ b/src/facet/inspection/_explainer.py
@@ -12,7 +12,7 @@ import shap
 from shap.explainers.explainer import Explainer
 from sklearn.base import BaseEstimator
 
-from pytools.common import AllTracker, inheritdoc, validate_type
+from pytools.api import AllTracker, inheritdoc, validate_type
 from sklearndf import ClassifierDF, LearnerDF, RegressorDF
 
 _EARLIEST_SUPPORTED_VERSION = version.LooseVersion("0.34")

--- a/src/facet/inspection/_inspection.py
+++ b/src/facet/inspection/_inspection.py
@@ -15,9 +15,9 @@ from facet.inspection._shap_decomposition import (
     ShapInteractionValueDecomposer,
     ShapValueDecomposer,
 )
-from pytools.common import AllTracker, inheritdoc
-from pytools.common.fit import FittableMixin
-from pytools.common.parallelization import ParallelizableMixin
+from pytools.api import AllTracker, inheritdoc
+from pytools.fit import FittableMixin
+from pytools.parallelization import ParallelizableMixin
 from pytools.viz.dendrogram import LinkageTree
 from sklearndf import ClassifierDF, LearnerDF, RegressorDF
 from sklearndf.pipeline import LearnerPipelineDF

--- a/src/facet/inspection/_shap.py
+++ b/src/facet/inspection/_shap.py
@@ -12,8 +12,8 @@ from shap.explainers.explainer import Explainer
 
 from facet import Sample
 from facet.crossfit import LearnerCrossfit
-from pytools.common.fit import FittableMixin
-from pytools.common.parallelization import ParallelizableMixin
+from pytools.fit import FittableMixin
+from pytools.parallelization import ParallelizableMixin
 from sklearndf.pipeline import (
     ClassifierPipelineDF,
     LearnerPipelineDF,

--- a/src/facet/inspection/_shap_decomposition.py
+++ b/src/facet/inspection/_shap_decomposition.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from facet.inspection._shap import ShapCalculator, ShapInteractionValuesCalculator
-from pytools.common.fit import FittableMixin
+from pytools.fit import FittableMixin
 
 log = logging.getLogger(__name__)
 

--- a/src/facet/selection/_selection.py
+++ b/src/facet/selection/_selection.py
@@ -15,9 +15,9 @@ from sklearn.model_selection import BaseCrossValidator
 
 from facet import Sample
 from facet.crossfit import CrossfitScores, LearnerCrossfit
-from pytools.common import inheritdoc, to_tuple
-from pytools.common.fit import FittableMixin
-from pytools.common.parallelization import ParallelizableMixin
+from pytools.api import inheritdoc, to_tuple
+from pytools.fit import FittableMixin
+from pytools.parallelization import ParallelizableMixin
 from sklearndf.pipeline import ClassifierPipelineDF, RegressorPipelineDF
 
 log = logging.getLogger(__name__)

--- a/src/facet/simulation/_simulation.py
+++ b/src/facet/simulation/_simulation.py
@@ -9,8 +9,8 @@ from typing import List
 import numpy as np
 import pandas as pd
 
-from pytools.common import AllTracker, inheritdoc
-from pytools.common.parallelization import ParallelizableMixin
+from pytools.api import AllTracker, inheritdoc
+from pytools.parallelization import ParallelizableMixin
 from sklearndf import ClassifierDF, RegressorDF
 from .partition import Partitioner, T_Number
 from .. import Sample

--- a/src/facet/simulation/partition/_partition.py
+++ b/src/facet/simulation/partition/_partition.py
@@ -9,7 +9,7 @@ from typing import *
 import numpy as np
 import pandas as pd
 
-from pytools.common.fit import FittableMixin
+from pytools.fit import FittableMixin
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
The structure of `pytools` modules and submodules changes as follows:
- `pytools.common.expression` → `pytools.expression`
- `pytools.common.fit` → `pytools.fit`
- `pytools.common.parallelization` → `pytools.parallelization`
- `pytools.common` → `pytools.api`