### PR TITLE
shap interaction values of binary classification not adding to 0

### DIFF
--- a/src/facet/inspection/_shap.py
+++ b/src/facet/inspection/_shap.py
@@ -808,10 +808,14 @@ class ClassifierShapInteractionValuesCalculator(
             # to ensure the values are returned as expected above,
             # and no information of class 1 is discarded, assert the
             # following:
-            assert np.allclose(raw_shap_tensors[0], -raw_shap_tensors[1]), (
-                "shap interaction values of binary classifiers must add up to 0.0 "
-                "for each observation and feature pair"
-            )
+            if not np.allclose(raw_shap_tensors[0], -raw_shap_tensors[1]):
+                _raw_shap_tensor_totals = raw_shap_tensors[0] + raw_shap_tensors[1]
+                log.warning(
+                    "shap interaction values of binary classifiers must add up to 0.0 "
+                    "for each observation and feature pair, but total shap values range "
+                    f"from {_raw_shap_tensor_totals.min():g} "
+                    f"to {_raw_shap_tensor_totals.max():g}"
+                )
 
             # all good: proceed with SHAP values for class 0:
             raw_shap_tensors = raw_shap_tensors[:1]


### PR DESCRIPTION
This PR follows from #24 and the issue #12. The previous correction was placed in the `ClassifierShapValuesCalculator` and not in the `ClassifierShapInteractionValuesCalculator` which is what generated the initial issue log. This PR makes the requisite changes to `ClassifierShapInteractionValuesCalculator`. This would make both functions consistent in using a warning instead of an assertion. However, it may mean we can restore the  `ClassifierShapValuesCalculator` to its original rigour.

Local pytest run found all 24 tests passed. 
