### PR TITLE
Update GitHub Org in CI/CD Pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,13 +2,13 @@ resources:
   repositories:
     - repository: sklearndf
       type: github
-      endpoint: konst-int-i # todo - update to final github org
-      name: konst-int-i/sklearndf # todo - update to final github org
+      endpoint: BCG-Gamma
+      name: BCG-Gamma/sklearndf
       ref: develop # todo - update to stable release
     - repository: pytools
       type: github
-      endpoint: konst-int-i # todo - update to final github org
-      name: konst-int-i/pytools # todo - update to final github org
+      endpoint: BCG-Gamma
+      name: BCG-Gamma/pytools
       ref: develop # todo - update to stable release
 
 stages:


### PR DESCRIPTION
**This PR**
* Updates the repos in the `azure-pipelines.yml` to the new `BCG-Gamma` org

**Run instructions**
* When triggering a run for this branch, we should see the [Azure pipelines](https://dev.azure.com/gamma-facet/facet) succeeding.