### PR TITLE
add first version of make.py for docs build

### DIFF
--- a/sphinx/make.py
+++ b/sphinx/make.py
@@ -92,7 +92,7 @@ html = MakeCommand(
     command="html",
     description="build facet Sphinx docs as HTML",
     python_target=fun_html,
-    depends_on=(clean, apidoc),
+    depends_on=(clean,),
 )
 
 available_cmds = (clean, apidoc, html)


### PR DESCRIPTION
**PR**
Provides a `make.py` for Sphinx-builds that should run well on different platforms.

**To run**
With the `facet-dev` environment active, changedir to `sphinx/` and run `python make.py html` to build the HTML docs.

The script works well for me, but of course feedback from you (esp. Windows users!) will be essential to merging this PR.

@j-ittner There are some other (obsolete?) targets still in `Makefile` we might consider to either drop or migrate.