### PR TITLE
Change capitalisation of "started" to align with pytools and sklearn df

### DIFF
--- a/sphinx/source/getting_started.rst
+++ b/sphinx/source/getting_started.rst
@@ -1,6 +1,6 @@
 .. _getting-started:
 
-Getting Started with
+Getting started with
 ====================
 
 .. include:: ../../README.rst


### PR DESCRIPTION
Align capitalisation "Getting started" of Facet
![image](https://user-images.githubusercontent.com/25201990/97113458-64883480-16e2-11eb-8e98-137c1b34458e.png)

With the others 
![image](https://user-images.githubusercontent.com/25201990/97113443-48849300-16e2-11eb-964d-d7d02d9c4ef4.png)
![image](https://user-images.githubusercontent.com/25201990/97113444-4de1dd80-16e2-11eb-9609-965a63efc5af.png)
