### PR TITLE
bugfix: pytools now built using flit

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,8 +140,9 @@ stages:
               export PYTHONPATH=$(System.DefaultWorkingDirectory)/facet/src/
               conda env create -f environment.yml
               conda activate facet-develop
+              pip install flit
               cd $(System.DefaultWorkingDirectory)/pytools/
-              pip install -e .
+              flit install -s
               cd $(System.DefaultWorkingDirectory)/sklearndf/
               pip install -e .
               cd $(System.DefaultWorkingDirectory)/facet/


### PR DESCRIPTION
This PR adjusts the DevOps test pipeline to build Pytools without `setup.py`