### PR TITLE
 Adapt pipeline as sklearndf is also built with new approach now

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,7 +144,7 @@ stages:
               cd $(System.DefaultWorkingDirectory)/pytools/
               flit install -s
               cd $(System.DefaultWorkingDirectory)/sklearndf/
-              pip install -e .
+              flit install -s
               cd $(System.DefaultWorkingDirectory)/facet/
               pip install pytest-azurepipelines
               coverage run -m pytest test/test/


### PR DESCRIPTION
This PR adjusts the symbolic install done of `sklearndf` in the azure-pipeline, to adapt for changes done by
https://github.com/BCG-Gamma/sklearndf/pull/54

*Note:* merge this **after** https://github.com/BCG-Gamma/sklearndf/pull/54 