### PR TITLE
add azure badge links and update conda install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -297,7 +297,7 @@ or have a look at
 .. |pypi| image:: https://badge.fury.io/py/gamma-facet.svg
     :target: https://pypi.org/project/gamma-facet/
 
-.. |azure_build| image:: https://dev.azure.com/gamma-facet/facet/_apis/build/status/BCG-Gamma.facet?repoName=BCG-Gamma%2Ffacet&branchName=develop.svg
+.. |azure_build| image:: https://dev.azure.com/gamma-facet/facet/_apis/build/status/BCG-Gamma.facet?repoName=BCG-Gamma%2Ffacet&branchName=develop
    :target: https://dev.azure.com/gamma-facet/facet/_build?definitionId=7&_a=summary
 
 .. |azure_code_cov| image:: https://img.shields.io/azure-devops/coverage/gamma-facet/facet/_build?definitionId=7.svg


### PR DESCRIPTION
This PR adds azure badge links for build and coverage and updates the conda install instructions. Note the azure gitbadges will not render correctly until the Azure pipelines are made public. 