### PR TITLE
Add automatic docs deployment to GitHub Pages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -342,7 +342,7 @@ stages:
     jobs:
     - job:
       displayName: 'Build and publish docs'
-      #  condition: eq(variables.master_or_release, 'True')
+      condition: eq(variables.master_or_release, 'True')
 
       pool:
           vmImage: 'ubuntu-latest'


### PR DESCRIPTION
This PR adds the automatic deployment of the sphinx docs to GitHub pages, following the implementation for `pytools` introduced in the following PRs:
- https://github.com/BCG-Gamma/pytools/pull/81
- https://github.com/BCG-Gamma/pytools/pull/87

The documentation is hosted at https://bcg-gamma.github.io/facet (once enabled in the repo settings)