### PR TITLE
update documentation section in contribution guide

### DIFF
--- a/sphinx/source/contribution_guide.rst
+++ b/sphinx/source/contribution_guide.rst
@@ -276,13 +276,13 @@ Before building the documentation ensure the ``facet-develop`` environment is ac
 the documentation build has a number of key dependencies specified in the
 ``environment.yml`` file, specifically:
 
-- sphinx = 3.2.*
+- sphinx
 
-- pydata-sphinx-theme = 0.4.*
+- pydata-sphinx-theme
 
-- nbsphinx = 0.7.*
+- nbsphinx
 
-- sphinx-autodoc-typehints = 1.11.*
+- sphinx-autodoc-typehints
 
 To generate the Sphinx documentation, run ``python make.py html`` from within
 ``/sphinx``. By default this will clean any previous build. The generated Sphinx


### PR DESCRIPTION
This PR revises and expands the documentation section of the contribution guidelines. Please note in a subsequent PR the local path setting in the tutorial notebooks will be removed.

To check navigate to the Sphinx folder and run `python make.py html`. Example below:

![image](https://user-images.githubusercontent.com/17013354/99994444-eab29c00-2db0-11eb-97f8-e3c54d3633f2.png)
