### PR TITLE
update hist bar colour to reference updated colour scheme in pytools

### DIFF
--- a/src/facet/simulation/viz/_style.py
+++ b/src/facet/simulation/viz/_style.py
@@ -250,7 +250,7 @@ class SimulationMatplotStyle(MatplotStyle, SimulationStyle):
         ax.bar(
             x=x_values,
             height=y_values,
-            color=SimulationMatplotStyle.__COLOR_BARS,
+            color=self.colors.fill_1,
             align="center",
             width=SimulationMatplotStyle.__WIDTH_BARS,
         )


### PR DESCRIPTION
This PR updates the histogram bars colour reference for FACET simulation visualisation to reference the updates to colour schemes in pytools (introduce class ColorScheme to module pytools.viz 109).