### PR TITLE
Bugfix/pipeline fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,13 +35,7 @@ variables:
     branchName: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
     branchName: $[ replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', '') ]
-  master_or_release: >
-    ${{ or(
-    startsWith(variables['branchName'], 'release'),
-    eq(variables['branchName'], 'master'),
-    eq(variables['Build.Reason'], 'Schedule')
-    )
-    }}
+  master_or_release: $[ or(startsWith(variables['branchName'], 'release'), eq(variables['branchName'], 'master'), eq(variables['Build.Reason'], 'Schedule')) ]
 
 stages:
   # check code quality first to fail fast (isort, flake8, black)


### PR DESCRIPTION
This PR fixes two issues identified in the release process for pytools [here](https://github.com/BCG-Gamma/pytools/pull/125):

- Removes redundant pipeline run for release branch: was triggered twice due to branch name `release/...` and target branch `master`, now only the latter trigger remains
- Inlines the `master_or_release` variable to avoid a YAML parsing error that always rendered the result `False` for all pipelines, always skipping the stages based on that variable being `True` (full build matrix, docs deployment, GitHub release)