### PR TITLE
FIX: update filepath and provide stage name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -363,9 +363,9 @@ stages:
               script: |
                 set -e
                 eval "$(conda shell.bash hook)"
-                cd $(Build.SourcesDirectory)
-                git archive --format=zip --output $(System.DefaultWorkingDirectory)/static_scan/archive.zip HEAD
-                cd $(System.DefaultWorkingDirectory)/static_scan
+                cd $(System.DefaultWorkingDirectory)
+                mkdir static_scan
+                git archive --format=zip --output static_scan/archive.zip HEAD
                 ls
 
 #          - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -363,8 +363,14 @@ stages:
               script: |
                 set -e
                 eval "$(conda shell.bash hook)"
-                cd $(Build.AgentDirectory)
+                cd $(Build.SourcesDirectory)
                 git archive --format=zip --output $(Build.ArtifactStagingDirectory)/facet/$(Build.BuildNumber).zip HEAD
+
+          - task: PublishBuildArtifacts@1
+            inputs:
+              pathtoPublish: $(Build.ArtifactStagingDirectory)/facet/$(Build.BuildNumber).zip
+              artifactName: $(BUILD_SYSTEM)_$(PKG_DEPENDENCIES)
+              publishLocation: Container
 
           - task: Veracode@3
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -348,7 +348,7 @@ stages:
             publishLocation: Container
 
   # apply veracode static code analysis during nightly build
-  - stage:
+  - stage: veracode_check
     displayName: 'Veracode check'
 
     jobs:
@@ -363,7 +363,7 @@ stages:
               AnalysisService: 'veracode'
               veracodeAppProfile: 'FACET'
               version: '$(Build.BuildNumber)'
-              filepath: '$(Build.ArtifactStagingDirectory)'
+              filepath: '/'
               sandboxName: 'facet'
               createSandBox: false
               createProfile: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -364,12 +364,19 @@ stages:
                 set -e
                 eval "$(conda shell.bash hook)"
                 cd $(Build.SourcesDirectory)
-                git archive --format=zip --output $(Build.ArtifactStagingDirectory)/facet/$(Build.BuildNumber).zip HEAD
+                pwd
+                git status
+                git archive --format=zip --output archive/facet_$(Build.BuildNumber).zip HEAD
+
+          - task: CopyFiles@2
+            inputs:
+              sourceFolder: $(Build.SourcesDirectory)/archive
+              targetFolder: $(Build.ArtifactStagingDirectory)
 
           - task: PublishBuildArtifacts@1
             inputs:
-              pathtoPublish: $(Build.ArtifactStagingDirectory)/facet/$(Build.BuildNumber).zip
-              artifactName: $(BUILD_SYSTEM)_$(PKG_DEPENDENCIES)
+              pathtoPublish: $(Build.ArtifactStagingDirectory)
+              artifactName: facet_$(Build.BuildNumber)
               publishLocation: Container
 
           - task: Veracode@3
@@ -378,7 +385,7 @@ stages:
               AnalysisService: 'veracode'
               veracodeAppProfile: 'FACET'
               version: '$(Build.BuildNumber)'
-              filepath: '/'
+              filepath: '$(Build.ArtifactStagingDirectory)'
               sandboxName: 'facet'
               createSandBox: false
               createProfile: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -365,8 +365,10 @@ stages:
                 eval "$(conda shell.bash hook)"
                 cd $(Build.SourcesDirectory)
                 pwd
+                ls
                 git status
-                git archive --format=zip --output archive/facet_$(Build.BuildNumber).zip HEAD
+                zip -r $(Build.ArtifactStagingDirectory)/facet.zip $(System.DefaultWorkingDirectory)
+                git archive --format=zip --output $(System.DefaultWorkingDirectory)/archive.zip HEAD
 
           - task: CopyFiles@2
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -364,8 +364,8 @@ stages:
                 set -e
                 eval "$(conda shell.bash hook)"
                 cd $(Build.SourcesDirectory)
-                git archive --format=zip --output $(System.DefaultWorkingDirectory)/archive.zip HEAD
-                cd $(System.DefaultWorkingDirectory)
+                git archive --format=zip --output $(System.DefaultWorkingDirectory)/static_scan/$(Build.BuildNumber).zip HEAD
+                cd $(System.DefaultWorkingDirectory)/static_scan
                 ls
 
 #          - task: CopyFiles@2
@@ -385,7 +385,7 @@ stages:
               AnalysisService: 'veracode'
               veracodeAppProfile: 'FACET'
               version: '$(Build.BuildNumber)'
-              filepath: '$(System.DefaultWorkingDirectory)'
+              filepath: '$(System.DefaultWorkingDirectory)/static_scan'
               sandboxName: 'facet'
               createSandBox: false
               createProfile: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -364,7 +364,7 @@ stages:
                 set -e
                 eval "$(conda shell.bash hook)"
                 cd $(Build.SourcesDirectory)
-                git archive --format=zip --output $(System.DefaultWorkingDirectory)/static_scan/$(Build.BuildNumber).zip HEAD
+                git archive --format=zip --output $(System.DefaultWorkingDirectory)/static_scan/archive.zip HEAD
                 cd $(System.DefaultWorkingDirectory)/static_scan
                 ls
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -364,22 +364,20 @@ stages:
                 set -e
                 eval "$(conda shell.bash hook)"
                 cd $(Build.SourcesDirectory)
-                pwd
-                ls
-                git status
-                zip -r $(Build.ArtifactStagingDirectory)/facet.zip $(System.DefaultWorkingDirectory)
                 git archive --format=zip --output $(System.DefaultWorkingDirectory)/archive.zip HEAD
+                cd $(System.DefaultWorkingDirectory)
+                ls
 
-          - task: CopyFiles@2
-            inputs:
-              sourceFolder: $(Build.SourcesDirectory)/archive
-              targetFolder: $(Build.ArtifactStagingDirectory)
+#          - task: CopyFiles@2
+#            inputs:
+#              sourceFolder: $(Build.SourcesDirectory)/archive
+#              targetFolder: $(Build.ArtifactStagingDirectory)
 
-          - task: PublishBuildArtifacts@1
-            inputs:
-              pathtoPublish: $(Build.ArtifactStagingDirectory)
-              artifactName: facet_$(Build.BuildNumber)
-              publishLocation: Container
+#          - task: PublishBuildArtifacts@1
+#            inputs:
+#              pathtoPublish: $(Build.ArtifactStagingDirectory)
+#              artifactName: facet_$(Build.BuildNumber)
+#              publishLocation: Container
 
           - task: Veracode@3
             inputs:
@@ -387,7 +385,7 @@ stages:
               AnalysisService: 'veracode'
               veracodeAppProfile: 'FACET'
               version: '$(Build.BuildNumber)'
-              filepath: '$(Build.ArtifactStagingDirectory)'
+              filepath: '$(System.DefaultWorkingDirectory)'
               sandboxName: 'facet'
               createSandBox: false
               createProfile: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -357,6 +357,15 @@ stages:
         #condition: eq(variables['Build.Reason'], 'Schedule')
 
         steps:
+          - task: Bash@3
+            inputs:
+              targetType: 'inline'
+              script: |
+                set -e
+                eval "$(conda shell.bash hook)"
+                cd $(Build.AgentDirectory)
+                git archive --format=zip --output $(Build.ArtifactStagingDirectory)/facet/$(Build.BuildNumber).zip HEAD
+
           - task: Veracode@3
             inputs:
               ConnectionDetailsSelection: 'Endpoint'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -354,7 +354,7 @@ stages:
     jobs:
       - job:
         displayName: 'Veracode check'
-        #condition: eq(variables['Build.Reason'], 'Schedule')
+        condition: eq(variables['Build.Reason'], 'Schedule')
 
         steps:
           - task: Bash@3
@@ -366,18 +366,6 @@ stages:
                 cd $(System.DefaultWorkingDirectory)
                 mkdir static_scan
                 git archive --format=zip --output static_scan/archive.zip HEAD
-                ls
-
-#          - task: CopyFiles@2
-#            inputs:
-#              sourceFolder: $(Build.SourcesDirectory)/archive
-#              targetFolder: $(Build.ArtifactStagingDirectory)
-
-#          - task: PublishBuildArtifacts@1
-#            inputs:
-#              pathtoPublish: $(Build.ArtifactStagingDirectory)
-#              artifactName: facet_$(Build.BuildNumber)
-#              publishLocation: Container
 
           - task: Veracode@3
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -354,7 +354,7 @@ stages:
     jobs:
       - job:
         displayName: 'Veracode check'
-        condition: eq(variables['Build.Reason'], 'Schedule')
+        #condition: eq(variables['Build.Reason'], 'Schedule')
 
         steps:
           - task: Veracode@3


### PR DESCRIPTION
This PR ensures the Veracode static code scan stage of the nightly build in Azure pipelines is directed and uploads the correct zip file.