### PR TITLE
FIX: drop support for joblib v0.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,18 +14,14 @@ dist-name = "gamma-facet"
 license = "Apache Software License v2.0"
 
 requires = [
-    "boruta >=0.3",
-    "lightgbm >=3.0",
     "shap >=0.34,<0.38",
-    "matplotlib >=3.1,<3.4",
-    "scikit-learn >=0.21,<0.24",
     "pandas >=0.24,<1.3",
     "numpy >=1.16,<1.20",
     "scipy >=1.2,<1.6",
     "pyyaml >=5.0",
-    "joblib >=0.14,<1.1",
-    "gamma-pytools >=1.0.1",
+    "gamma-pytools >=1.1.0",
     "sklearndf >=1.0.1",
+    "packaging >= 20",
 ]
 
 requires-python = ">=3.6,<3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires = [
     "numpy >=1.16,<1.20",
     "scipy >=1.2,<1.6",
     "pyyaml >=5.0",
-    "joblib >=0.13,<=1.0",
+    "joblib >=0.14,<1.1",
     "gamma-pytools >=1.0.1",
     "sklearndf >=1.0.1",
 ]
@@ -74,7 +74,7 @@ python          =  "=3.6.*"
 pandas          =  "=0.24.*"
 numpy           =  "=1.16.*"
 scipy           =  "=1.2.*"
-joblib          =  "=0.13.*"
+joblib          =  "=0.14.*"
 scikit-learn    =  "=0.21.*"
 shap            =  "=0.34"
 matplotlib      =  "=3.0.*"
@@ -84,7 +84,7 @@ python          =  "=3.8.*"
 pandas          =  "=1.1.*"
 numpy           =  "=1.19.*"
 scipy           =  "=1.5.*"
-joblib          =  "=0.16.*"
+joblib          =  "=1.0.*"
 scikit-learn    =  "=0.23.*"
 shap            =  "=0.37"
 matplotlib      =  "=3.3.*"
@@ -94,7 +94,7 @@ python          =  ">=3.6,<3.9"
 pandas          =  ">=0.24"
 numpy           =  ">=1.16"
 scipy           =  ">=1.2,<1.6"
-joblib          =  ">=0.13"
+joblib          =  ">=0.14"
 scikit-learn    =  ">=0.21,<0.24"
 shap            =  ">=0.35"
 matplotlib      =  ">=3"

--- a/sphinx/source/faqs.rst
+++ b/sphinx/source/faqs.rst
@@ -157,5 +157,5 @@ Bibtex entry::
      title={FACET},
      author={FACET Team at BCG GAMMA},
      year={2021},
-     note={Python package version 1.0.1)
+     note={Python package version 1.1.0}
      }

--- a/src/facet/__init__.py
+++ b/src/facet/__init__.py
@@ -6,7 +6,7 @@ inspection, and simulation.
 """
 
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 __logo__ = (
     r"""


### PR DESCRIPTION
joblib v0.13 raised an exception while pickling objects for FACET simulations; this is working with Joblib 0.14 and later.