### PR TITLE
DOC: parallelise LearnerInspector in getting started example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -204,7 +204,7 @@ features in a model are:
 
     # fit the model inspector
     from facet.inspection import LearnerInspector
-    inspector = LearnerInspector()
+    inspector = LearnerInspector(n_jobs=-3)
     inspector.fit(crossfit=ranker.best_model_crossfit_)
 
 **Synergy**

--- a/sphinx/auxiliary/Diabetes_getting_started_example.ipynb
+++ b/sphinx/auxiliary/Diabetes_getting_started_example.ipynb
@@ -353,7 +353,7 @@
    "source": [
     "# fit the model inspector\n",
     "from facet.inspection import LearnerInspector\n",
-    "inspector = LearnerInspector()\n",
+    "inspector = LearnerInspector(n_jobs=-3)\n",
     "inspector.fit(crossfit=ranker.best_model_crossfit_)"
    ]
   },

--- a/sphinx/source/tutorial/Predictive_Maintenance_Regression_with_Facet.ipynb
+++ b/sphinx/source/tutorial/Predictive_Maintenance_Regression_with_Facet.ipynb
@@ -1123,7 +1123,7 @@
    ],
    "source": [
     "# run inspector\n",
-    "regression_inspector = LearnerInspector()\n",
+    "regression_inspector = LearnerInspector(n_jobs=-3)\n",
     "regression_inspector.fit(\n",
     "    n_jobs=-3, verbose=False, crossfit=regressor_ranker.best_model_crossfit_\n",
     ")"


### PR DESCRIPTION
Demonstrate that the `LearnerInspector` can be parallelised, to avoid runtime issues as experienced in issue #215.