### PR TITLE
BUILD: add conda-verify

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,7 +219,7 @@ stages:
         - script: dir $(Build.SourcesDirectory)
 
         - script: |
-            conda install -y -c anaconda conda-build=3.20.5 toml=0.10.* flit=3.0.*
+            conda install -y -c anaconda conda-build=3.20.5 conda-verify toml=0.10.* flit=3.0.*
           displayName: 'Install conda-build, flit, toml'
           condition: eq(variables['BUILD_SYSTEM'], 'conda')
 
@@ -317,7 +317,7 @@ stages:
         - script: dir $(Build.SourcesDirectory)
 
         - script: |
-            conda install -y -c anaconda conda-build=3.20.5 toml=0.10.* flit=3.0.*
+            conda install -y -c anaconda conda-build=3.20.5 conda-verify toml=0.10.* flit=3.0.*
           displayName: 'Install conda-build, flit, toml'
           condition: eq(variables['BUILD_SYSTEM'], 'conda')
 

--- a/condabuild/meta.yaml
+++ b/condabuild/meta.yaml
@@ -1,5 +1,3 @@
-{% set setup_py_data = load_setup_py_data() %}
-
 package:
   name: gamma-facet
   version: {{ environ.get('FACET_BUILD_FACET_VERSION') }}


### PR DESCRIPTION
Minor changes to conda build setup
  - remove now obsolete script call in meta.yaml
  - add conda-verify as a build dependency

Not expecting any major impact from this change.