### PR TITLE
API: rename LearnerInspector.features to .features_

### DIFF
--- a/src/facet/inspection/_inspection.py
+++ b/src/facet/inspection/_inspection.py
@@ -337,7 +337,7 @@ class LearnerInspector(
         return self._shap_calculator.output_names_
 
     @property
-    def features(self) -> List[str]:
+    def features_(self) -> List[str]:
         """
         The names of the features used to fit the learner pipeline explained by this
         inspector.
@@ -713,7 +713,7 @@ class LearnerInspector(
             (n_features, n_outputs * n_features)
         """
 
-        n_features = len(self.features)
+        n_features = len(self.features_)
         n_outputs = len(self.output_names_)
 
         # get a feature interaction array with shape

--- a/test/test/facet/test_shap_decomposition.py
+++ b/test/test/facet/test_shap_decomposition.py
@@ -137,7 +137,7 @@ def test_shap_decomposition(regressor_inspector: LearnerInspector) -> None:
 
         # check basic matrix properties
 
-        n_features = len(regressor_inspector.features)
+        n_features = len(regressor_inspector.features_)
 
         for matrix in (syn_matrix, syn_matrix_asym, red_matrix, red_matrix_asym):
             # matrix shape is n_features x n_features


### PR DESCRIPTION
Attribute `features_` is only defined for fitted inspectors, so we add a trailing underscore.