### PR TITLE
BUILD: add support for shap v0.38.*

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,6 @@ dependencies:
   - scikit-learn >=0.23.1,<0.24
   - scipy >= 1.5
   - seaborn = 0.11.*
-  - shap >= 0.35
   - sklearndf >=1.0,<2
   - sphinx = 3.4.*
   - sphinx-autodoc-typehints = 1.11.*
@@ -42,3 +41,5 @@ dependencies:
   - typing_inspect >= 0.4
   - xlrd >= 1.2
   - yaml > 0.2
+  - pip:
+      - shap >=0.35,<0.39

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires = [
     "packaging      >=20",
     "pandas         >=0.24,<1.3",
     "scipy          >=1.2,<1.6",
-    "shap           >=0.34,<0.38",
+    "shap           >=0.34,<0.39",
     "sklearndf      >=1.0.1,<2",
     # additional requirements of sklearndf
     "boruta         >=0.3",
@@ -100,7 +100,7 @@ packaging      = ">=20"
 pandas         = "<1.3"
 python         = "=3.8.*"
 scipy          = "<1.6"
-shap           = "=0.37.*"
+shap           = "=0.38.*"
 sklearndf      = "<2"
 # additional requirements of sklearndf
 boruta         = ">=0.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,9 @@ scikit-learn   = "=0.23.*"
 # additional requirements of gamma-pytools
 joblib         = "<1.1"
 typing_inspect = "<0.7"
+# additional requirements of shap 0.38
+# todo: remove once supported via shap 0.38 requirements
+ipython        = "7.*"
 
 [tool.black]
 # quiet = "True"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ packaging      = ">=20"
 pandas         = "<1.3"
 python         = "=3.8.*"
 scipy          = "<1.6"
-shap           = "=0.38.*"
+shap           = ">=0.37,<0.39"
 sklearndf      = "<2"
 # additional requirements of sklearndf
 boruta         = ">=0.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ joblib         = "<1.1"
 typing_inspect = "<0.7"
 # additional requirements of shap 0.38
 # todo: remove once supported via shap 0.38 requirements
-ipython        = "7.*"
+ipython        = "=7.*"
 
 [tool.black]
 # quiet = "True"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ requires = [
     # additional requirements of gamma-pytools
     "joblib         >=0.13,<1.1",
     "typing_inspect >=0.4,<0.7",
+    # additional requirements of shap 0.38
+    # todo: remove once supported via shap 0.38 requirements
+    "ipython",
 ]
 
 requires-python = ">=3.6,<3.9"
@@ -109,9 +112,6 @@ scikit-learn   = "=0.23.*"
 # additional requirements of gamma-pytools
 joblib         = "<1.1"
 typing_inspect = "<0.7"
-# additional requirements of shap 0.38
-# todo: remove once supported via shap 0.38 requirements
-ipython        = "=7.*"
 
 [tool.black]
 # quiet = "True"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires = [
     "typing_inspect >=0.4,<0.7",
     # additional requirements of shap 0.38
     # todo: remove once supported via shap 0.38 requirements
-    "ipython",
+    "ipython        >=7",
 ]
 
 requires-python = ">=3.6,<3.9"

--- a/src/facet/inspection/_explainer.py
+++ b/src/facet/inspection/_explainer.py
@@ -26,20 +26,23 @@ __all__ = [
 ]
 
 __shap_version__ = version.parse(shap.__version__)
-__shap_earliest__ = version.parse("0.34")
+__shap_earliest_supported__ = version.parse("0.34")
 __shap_0_36__ = version.parse("0.36")
-__shap_latest__ = version.parse("0.38")
+__shap_not_yet_supported__ = version.parse("0.39")
 
 
 #
 # Ensure we have a supported version of the shap package
 #
 
-if __shap_version__ < __shap_earliest__ or __shap_version__ >= __shap_latest__:
-    raise ImportError(
+if (
+    __shap_version__ < __shap_earliest_supported__
+    or __shap_version__ >= __shap_not_yet_supported__
+):
+    log.warning(
         f"shap package v{__shap_version__} is not supported; "
-        f"please use v{__shap_earliest__} or later"
-        f"but not v{__shap_latest__} or later"
+        f"current support includes versions starting at v{__shap_earliest_supported__} "
+        f"and preceding v{__shap_not_yet_supported__}"
     )
 
 #

--- a/src/facet/inspection/_explainer.py
+++ b/src/facet/inspection/_explainer.py
@@ -74,7 +74,7 @@ __tracker = AllTracker(globals())
 
 class BaseExplainer(metaclass=ABCMeta):
     """
-    Abstract base class of SHAP explainers, providing stubs for methods used by FAET
+    Abstract base class of SHAP explainers, providing stubs for methods used by FACET
     but not consistently supported by class :class:`shap.Explainer` across different
     versions of the `shap` package.
     """

--- a/src/facet/inspection/_shap.py
+++ b/src/facet/inspection/_shap.py
@@ -18,9 +18,9 @@ from sklearndf.pipeline import (
     RegressorPipelineDF,
 )
 
+from ..crossfit import LearnerCrossfit
+from ..data import Sample
 from ._explainer import BaseExplainer, ExplainerFactory
-from facet.crossfit import LearnerCrossfit
-from facet.data import Sample
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR catches up with the latest `shap` release, 0.38.1

It also makes FACET more robust towards handling API changes in newer `shap` versions, preventing exceptions at import time even if some `shap` classes cannot be imported. This makes it possible to add dynamic support for new `shap` versions by providing a custom `ExplainerFactory`.