### PR TITLE
FIX: downgrade scipy to 1.5.* in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - python = 3.8.*
   - pyyaml >= 5.1
   - scikit-learn >=0.23.1,<0.24
-  - scipy >= 1.5
+  - scipy = 1.5.* # todo: upgrade to 1.6 once we support scikit-learn 0.24
   - seaborn = 0.11.*
   - sklearndf >=1.0,<2
   - sphinx = 3.4.*

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - python = 3.8.*
   - pyyaml >= 5.1
   - scikit-learn >=0.23.1,<0.24
-  - scipy = 1.5.* # todo: upgrade to 1.6 once we support scikit-learn 0.24
+  - scipy = 1.5.*  # todo: upgrade to 1.6 once we support scikit-learn 0.24
   - seaborn = 0.11.*
   - sklearndf >=1.0,<2
   - sphinx = 3.4.*


### PR DESCRIPTION
There is an [incompatibility](https://stackoverflow.com/questions/65682019/attributeerror-str-object-has-no-attribute-decode-in-fitting-logistic-regre) between scikit-learn < 0.24 and scipy >= 1.6.

We do not yet support scikit-learn 0.24, so we downgrade scipy to 1.5 in the develop environment.