### PR TITLE
API: remove the experimental 'shuffle_features' option

### DIFF
--- a/src/facet/selection/_selection.py
+++ b/src/facet/selection/_selection.py
@@ -252,7 +252,6 @@ class LearnerRanker(
         cv: Optional[BaseCrossValidator],
         scoring: Union[str, Callable[[float, float], float], None] = None,
         ranking_scorer: Callable[[np.ndarray], float] = None,
-        shuffle_features: Optional[bool] = None,
         random_state: Union[int, RandomState, None] = None,
         n_jobs: Optional[int] = None,
         shared_memory: Optional[bool] = None,
@@ -273,8 +272,6 @@ class LearnerRanker(
             The resulting score is used to rank all crossfits (highest score is best).
             Defaults to :meth:`.default_ranking_scorer`, calculating
             `mean(scores) - 2 * std(scores, ddof=1)`
-        :param shuffle_features: if ``True``, shuffle column order of features for
-            every crossfit (default: ``False``)
         :param random_state: optional random seed or random state for shuffling the
             feature column order
         """
@@ -308,7 +305,6 @@ class LearnerRanker(
             if ranking_scorer is None
             else ranking_scorer
         )
-        self.shuffle_features = shuffle_features
         self.random_state = random_state
 
         # initialise state
@@ -504,7 +500,6 @@ class LearnerRanker(
             LearnerCrossfit(
                 pipeline=pipeline,
                 cv=self.cv,
-                shuffle_features=self.shuffle_features,
                 random_state=self.random_state,
                 n_jobs=self.n_jobs,
                 shared_memory=self.shared_memory,

--- a/src/facet/validation/_validation.py
+++ b/src/facet/validation/_validation.py
@@ -264,8 +264,7 @@ class FullSampleValidator(BaseCrossValidator):
     test and in train.
 
     This can be useful to construct a :class:`.LearnerCrossfit` which
-    only shuffles the feature order across fits, or to inspect a single model fitted
-    on the full sample for fast indicative results.
+    inspects a single model fitted on the full sample for quick, indicative results.
     """
 
     def __init__(self, n_splits: int = 1):
@@ -311,7 +310,7 @@ class FullSampleValidator(BaseCrossValidator):
         """
         indices = np.arange(len(X))
         for i in range(self.n_splits):
-            yield (indices, indices)
+            yield indices, indices
 
     # noinspection PyPep8Naming
     def _iter_test_indices(self, X=None, y=None, groups=None) -> Iterator:

--- a/test/test/conftest.py
+++ b/test/test/conftest.py
@@ -178,7 +178,6 @@ def best_lgbm_crossfit(
     return LearnerCrossfit(
         pipeline=best_lgbm_regressor,
         cv=cv_kfold,
-        shuffle_features=True,
         random_state=42,
         n_jobs=n_jobs,
     ).fit(sample=sample)

--- a/test/test/facet/test_inspection.py
+++ b/test/test/facet/test_inspection.py
@@ -936,7 +936,6 @@ def fit_learner_ranker(
         grids=grids,
         cv=cv,
         scoring="f1_macro",
-        # shuffle_features=True,
         random_state=42,
         n_jobs=n_jobs,
     ).fit(sample=sample)

--- a/test/test/facet/test_simulation.py
+++ b/test/test/facet/test_simulation.py
@@ -44,7 +44,6 @@ def crossfit(
             ),
         ),
         cv=StationaryBootstrapCV(n_splits=N_SPLITS, random_state=42),
-        shuffle_features=False,
         n_jobs=n_jobs,
     ).fit(sample=sample)
 


### PR DESCRIPTION
Random permutations of feature sequence across splits of a crossfit was an experimental feature in the development of SHAP vector decomposition. It has little to none practical use hence we are removing it to keep the API as simple as possible.