### PR TITLE
API: consistently refer to all mean/std calculations as "aggregation"

### DIFF
--- a/src/facet/inspection/_shap_decomposition.py
+++ b/src/facet/inspection/_shap_decomposition.py
@@ -75,7 +75,7 @@ class ShapDecomposer(ShapGlobalExplainer):
         self.association_rel_asymmetric_: Optional[np.ndarray] = None
 
     def association(
-        self, absolute: bool, symmetrical: bool, std: bool
+        self, absolute: bool, symmetrical: bool, std: bool = False
     ) -> Optional[np.ndarray]:
         """[see superclass]"""
         if absolute:
@@ -94,7 +94,7 @@ class ShapDecomposer(ShapGlobalExplainer):
         # basic definitions
         #
 
-        shap_values: pd.DataFrame = shap_calculator.get_shap_values(consolidate="mean")
+        shap_values: pd.DataFrame = shap_calculator.get_shap_values(aggregation="mean")
         n_outputs: int = len(shap_calculator.output_names_)
         n_features: int = len(shap_calculator.feature_index_)
         n_observations: int = len(shap_values)
@@ -266,7 +266,7 @@ class ShapInteractionDecomposer(ShapDecomposer, ShapInteractionGlobalExplainer):
         """
 
     def synergy(
-        self, symmetrical: bool, absolute: bool, std: bool
+        self, symmetrical: bool, absolute: bool, std: bool = False
     ) -> Optional[np.ndarray]:
         """[see superclass]"""
         if absolute:
@@ -278,7 +278,7 @@ class ShapInteractionDecomposer(ShapDecomposer, ShapInteractionGlobalExplainer):
         return self.synergy_rel_ if symmetrical else self.synergy_rel_asymmetric_
 
     def redundancy(
-        self, symmetrical: bool, absolute: bool, std: bool
+        self, symmetrical: bool, absolute: bool, std: bool = False
     ) -> Optional[np.ndarray]:
         """[see superclass]"""
         if absolute:
@@ -297,7 +297,7 @@ class ShapInteractionDecomposer(ShapDecomposer, ShapInteractionGlobalExplainer):
         # basic definitions
         #
         shap_values: pd.DataFrame = shap_calculator.get_shap_interaction_values(
-            consolidate="mean"
+            aggregation="mean"
         )
         features: pd.Index = shap_calculator.feature_index_
         outputs: List[str] = shap_calculator.output_names_

--- a/src/facet/inspection/_shap_global_explanation.py
+++ b/src/facet/inspection/_shap_global_explanation.py
@@ -217,7 +217,7 @@ class ShapGlobalExplainer(FittableMixin[ShapCalculator], metaclass=ABCMeta):
 
     @abstractmethod
     def association(
-        self, absolute: bool, symmetrical: bool, std: bool
+        self, absolute: bool, symmetrical: bool, std: bool = False
     ) -> Optional[np.ndarray]:
         """
         The association matrix for all feature pairs.
@@ -276,7 +276,7 @@ class ShapInteractionGlobalExplainer(ShapGlobalExplainer, metaclass=ABCMeta):
 
     @abstractmethod
     def synergy(
-        self, symmetrical: bool, absolute: bool, std: bool
+        self, symmetrical: bool, absolute: bool, std: bool = False
     ) -> Optional[np.ndarray]:
         """
         The synergy matrix for all feature pairs.
@@ -298,7 +298,7 @@ class ShapInteractionGlobalExplainer(ShapGlobalExplainer, metaclass=ABCMeta):
 
     @abstractmethod
     def redundancy(
-        self, symmetrical: bool, absolute: bool, std: bool
+        self, symmetrical: bool, absolute: bool, std: bool = False
     ) -> Optional[np.ndarray]:
         """
         The redundancy matrix for all feature pairs.
@@ -546,7 +546,7 @@ class ShapValueContext(ShapContext):
 
     def __init__(self, shap_calculator: ShapCalculator, split_id: int) -> None:
         shap_values: pd.DataFrame = shap_calculator.get_shap_values(
-            consolidate=None
+            aggregation=None
         ).xs(split_id, level=0)
 
         def _p_i() -> np.ndarray:
@@ -585,7 +585,7 @@ class ShapInteractionValueContext(ShapContext):
 
     def __init__(self, shap_calculator: ShapCalculator, split_id: int) -> None:
         shap_values: pd.DataFrame = shap_calculator.get_shap_interaction_values(
-            consolidate=None
+            aggregation=None
         ).xs(split_id, level=0)
 
         n_features: int = len(shap_calculator.feature_index_)

--- a/src/facet/inspection/_shap_projection.py
+++ b/src/facet/inspection/_shap_projection.py
@@ -66,7 +66,7 @@ class ShapProjector(ShapGlobalExplainer, metaclass=ABCMeta):
         self.association_: Optional[AffinityMatrix] = None
 
     def association(
-        self, absolute: bool, symmetrical: bool, std: bool
+        self, absolute: bool, symmetrical: bool, std: bool = False
     ) -> Optional[np.ndarray]:
         """[see superclass]"""
         self._ensure_fitted()
@@ -162,7 +162,7 @@ class ShapInteractionVectorProjector(ShapProjector, ShapInteractionGlobalExplain
         self.redundancy_: Optional[AffinityMatrix] = None
 
     def synergy(
-        self, symmetrical: bool, absolute: bool, std: bool
+        self, symmetrical: bool, absolute: bool, std: bool = False
     ) -> Optional[np.ndarray]:
         """[see superclass]"""
         self._ensure_fitted()
@@ -171,7 +171,7 @@ class ShapInteractionVectorProjector(ShapProjector, ShapInteractionGlobalExplain
         )
 
     def redundancy(
-        self, symmetrical: bool, absolute: bool, std: bool
+        self, symmetrical: bool, absolute: bool, std: bool = False
     ) -> Optional[np.ndarray]:
         """[see superclass]"""
         self._ensure_fitted()

--- a/test/test/facet/test_inspection.py
+++ b/test/test/facet/test_inspection.py
@@ -124,12 +124,16 @@ def test_model_inspection(
     )
 
     # using an invalid consolidation method raises an exception
-    with pytest.raises(ValueError, match="unknown consolidation method: invalid"):
-        regressor_inspector.shap_values(consolidate="invalid")
+    with pytest.raises(ValueError, match="unknown aggregation method: invalid"):
+        regressor_inspector.shap_values(aggregation="invalid")
 
-    shap_values_raw: pd.DataFrame = regressor_inspector.shap_values(consolidate=None)
-    shap_values_mean = regressor_inspector.shap_values(consolidate="mean")
-    shap_values_std = regressor_inspector.shap_values(consolidate="std")
+    shap_values_raw: pd.DataFrame = regressor_inspector.shap_values(aggregation=None)
+    shap_values_mean = regressor_inspector.shap_values(
+        aggregation=LearnerInspector.AGG_MEAN
+    )
+    shap_values_std = regressor_inspector.shap_values(
+        aggregation=LearnerInspector.AGG_STD
+    )
 
     # method shap_values without parameter is equal to "mean" consolidation
     assert_frame_equal(shap_values_mean, regressor_inspector.shap_values())
@@ -204,7 +208,7 @@ def test_model_inspection_classifier_binary(
     ).fit(crossfit=iris_classifier_crossfit_binary)
 
     # calculate the shap value matrix, without any consolidation
-    shap_values = model_inspector.shap_values(consolidate=None)
+    shap_values = model_inspector.shap_values(aggregation=None)
 
     # do the shap values add up to predictions minus a constant value?
     _validate_shap_values_against_predictions(
@@ -301,7 +305,7 @@ def test_model_inspection_classifier_multi_class(
 ) -> None:
 
     # calculate the shap value matrix, without any consolidation
-    shap_values = iris_inspector_multi_class.shap_values(consolidate=None)
+    shap_values = iris_inspector_multi_class.shap_values(aggregation=None)
 
     # do the shap values add up to predictions minus a constant value?
     _validate_shap_values_against_predictions(
@@ -601,7 +605,7 @@ def test_model_inspection_classifier_interaction(
 
     # do the shap values add up to predictions minus a constant value?
     _validate_shap_values_against_predictions(
-        shap_values=model_inspector.shap_interaction_values(consolidate=None)
+        shap_values=model_inspector.shap_interaction_values(aggregation=None)
         .groupby(level=[0, 1])
         .sum(),
         crossfit=iris_classifier_crossfit_binary,

--- a/test/test/facet/test_shap_decomposition.py
+++ b/test/test/facet/test_shap_decomposition.py
@@ -20,7 +20,7 @@ def test_shap_decomposition(regressor_inspector: LearnerInspector) -> None:
     def _calculate_relative_syn_and_red(
         feature_x: str, feature_y: str, is_indirect_syn_valid: bool
     ) -> Tuple[float, float, float, float]:
-        iv = regressor_inspector.shap_interaction_values(consolidate=None)
+        iv = regressor_inspector.shap_interaction_values(aggregation=None)
         # Get 3 components for each feature:
         # S = interaction SHAP
         # A, B = independent SHAP


### PR DESCRIPTION
This PR renames all `consolidate` arguments of `LearnerInspector` and `ShapCalculator` to `aggregation`.
It breaks compatibility with FACET 1.0, but I suggest not to keep a deprecated `consolidate` argument because it will have been rarely used at this stage, and any code that uses it is very easy to fix.

Why change the name?
- it is more precise
- we use "consolidate" in other contexts, with a broader meaning of collecting/collating/aligning information (see method `LearnerInspector.shap_plot_data`