### PR TITLE
BUILD: add copy of old docs-versions folder

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -656,6 +656,8 @@ stages:
               cp -r $(Build.ArtifactStagingDirectory)/old_docs/docs .
               echo "Current docs contents:"
               tree docs
+              mkdir -p $(System.DefaultWorkingDirectory)/facet/sphinx/build/
+              cp -R docs/docs-version $(System.DefaultWorkingDirectory)/facet/sphinx/build/
               echo "Building sphinx docs"
               conda activate facet-develop
               cd $(System.DefaultWorkingDirectory)/facet


### PR DESCRIPTION
This corrects the scenario that older version.js files are not patched, by copying pre-existing docs-version folders where the makefile for docs expects them.