### PR TITLE
BUILD: exclude RC releases of next minor release in requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,14 @@ license = "Apache Software License v2.0"
 
 requires = [
     # direct requirements of gamma-facet
-    "gamma-pytools  =1.0,>=1.0.2",
+    "gamma-pytools  =1.0.*,>=1.0.2",
     "matplotlib     >=3.0,<3.4",
     "numpy          >=1.16,<1.21",
     "packaging      >=20",
     "pandas         >=0.24,<1.3",
     "scipy          >=1.2,<1.6",
     "shap           >=0.34,<0.39",
-    "sklearndf      =1.0,>=1.0.2",
+    "sklearndf      =1.0.*,>=1.0.2",
     # additional requirements of sklearndf
     "boruta         >=0.3",
     "lightgbm       >=3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = "Apache Software License v2.0"
 
 requires = [
     # direct requirements of gamma-facet
-    "gamma-pytools  ~=1.0.2",
+    "gamma-pytools  ~=1.0.2", 
     "matplotlib     >=3.0,<3.4",
     "numpy          >=1.16,<1.21",
     "packaging      >=20",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,14 @@ license = "Apache Software License v2.0"
 
 requires = [
     # direct requirements of gamma-facet
-    "gamma-pytools  =1.0.*,>=1.0.2",
+    "gamma-pytools  =1.0,>=1.0.2",
     "matplotlib     >=3.0,<3.4",
     "numpy          >=1.16,<1.21",
     "packaging      >=20",
     "pandas         >=0.24,<1.3",
     "scipy          >=1.2,<1.6",
     "shap           >=0.34,<0.39",
-    "sklearndf      =1.0.*,>=1.0.2",
+    "sklearndf      =1.0,>=1.0.2",
     # additional requirements of sklearndf
     "boruta         >=0.3",
     "lightgbm       >=3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,14 @@ license = "Apache Software License v2.0"
 
 requires = [
     # direct requirements of gamma-facet
-    "gamma-pytools  =1.0.*,>=1.0.2",
+    "gamma-pytools  ~=1.0.2",
     "matplotlib     >=3.0,<3.4",
     "numpy          >=1.16,<1.21",
     "packaging      >=20",
     "pandas         >=0.24,<1.3",
     "scipy          >=1.2,<1.6",
     "shap           >=0.34,<0.39",
-    "sklearndf      =1.0.*,>=1.0.2",
+    "sklearndf      ~=1.0.2",
     # additional requirements of sklearndf
     "boruta         >=0.3",
     "lightgbm       >=3.0",
@@ -96,7 +96,7 @@ joblib         = "=0.13.*"
 typing_inspect = "=0.4"
 
 [build.matrix.max]
-gamma-pytools  = "=1.0.*"
+gamma-pytools  = "~=1.0.2"
 matplotlib     = "=3.3.*"
 numpy          = "<1.21"
 packaging      = ">=20"
@@ -104,7 +104,7 @@ pandas         = "<1.3"
 python         = "=3.8.*"
 scipy          = "<1.6"
 shap           = ">=0.37,<0.39"
-sklearndf      = "=1.0.*"
+sklearndf      = "~=1.0.2"
 # additional requirements of sklearndf
 boruta         = ">=0.3"
 lightgbm       = ">=3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,14 @@ license = "Apache Software License v2.0"
 
 requires = [
     # direct requirements of gamma-facet
-    "gamma-pytools  >=1.0.2,<1.1",
+    "gamma-pytools  >=1.0.2,<1.1.0rc0",
     "matplotlib     >=3.0,<3.4",
     "numpy          >=1.16,<1.21",
     "packaging      >=20",
     "pandas         >=0.24,<1.3",
     "scipy          >=1.2,<1.6",
     "shap           >=0.34,<0.39",
-    "sklearndf      >=1.0.2,<1.1",
+    "sklearndf      >=1.0.2,<1.1.0rc0",
     # additional requirements of sklearndf
     "boruta         >=0.3",
     "lightgbm       >=3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,14 @@ license = "Apache Software License v2.0"
 
 requires = [
     # direct requirements of gamma-facet
-    "gamma-pytools  >=1.0.2,<1.1.0rc0",
+    "gamma-pytools  =1.0.*,>=1.0.2",
     "matplotlib     >=3.0,<3.4",
     "numpy          >=1.16,<1.21",
     "packaging      >=20",
     "pandas         >=0.24,<1.3",
     "scipy          >=1.2,<1.6",
     "shap           >=0.34,<0.39",
-    "sklearndf      >=1.0.2,<1.1.0rc0",
+    "sklearndf      =1.0.*,>=1.0.2",
     # additional requirements of sklearndf
     "boruta         >=0.3",
     "lightgbm       >=3.0",


### PR DESCRIPTION
The current setup on `develop` breaks the default build test, as for Conda, the `gamma-pytools` version specifier in place `>=1.0.2,<1.1` still allows any 1.1-RC version, as pre-releases seem not to be not excluded by default, and they meet the constraint of being lower than 1.1.*.:

https://dev.azure.com/gamma-facet/facet/_build/results?buildId=3443&view=logs&j=09dd16d0-0872-5106-121a-048cc4d08c2a&t=4946b2ab-680e-5c2a-25a7-369fdd80cbcd&l=12371