### PR TITLE
API: move bounds arguments from RangePartitioner.__init__() to .fit()

### DIFF
--- a/src/facet/data/partition/_partition.py
+++ b/src/facet/data/partition/_partition.py
@@ -6,6 +6,7 @@ import logging
 import math
 import operator as op
 from abc import ABCMeta, abstractmethod
+from numbers import Number
 from typing import Any, Generic, Iterable, Optional, Sequence, Tuple, TypeVar
 
 import numpy as np
@@ -31,7 +32,7 @@ __all__ = [
 
 T_Self = TypeVar("T_Self")
 T_Values = TypeVar("T_Values")
-T_Values_Numeric = TypeVar("T_Values_Numeric", int, float)
+T_Values_Numeric = TypeVar("T_Values_Numeric", bound=Number)
 
 #
 # Ensure all symbols introduced below are included in __all__

--- a/src/facet/data/partition/_partition.py
+++ b/src/facet/data/partition/_partition.py
@@ -90,11 +90,7 @@ class Partitioner(
     @property
     def partitions_(self) -> np.ndarray:
         """
-        Return central values of the partitions.
-
-        Requires that this partitioner has been fitted with a set of observed values.
-
-        :return: a sequence of central values for each partition
+        The central values of all partitions.
         """
         self._ensure_fitted()
         return self._partitions
@@ -102,9 +98,7 @@ class Partitioner(
     @property
     def frequencies_(self) -> np.ndarray:
         """
-        Return the count of observed elements in each partition.
-
-        :return: a sequence of value counts for each partition
+        The count of data points in each partition.
         """
         self._ensure_fitted()
         return self._frequencies
@@ -136,22 +130,17 @@ class Partitioner(
         return values
 
 
-@inheritdoc(match="[see superclass]")
+@inheritdoc(match="""[see superclass]""")
 class RangePartitioner(
     Partitioner[T_Values_Numeric], Generic[T_Values_Numeric], metaclass=ABCMeta
 ):
     """
-    Abstract base class for numerical partitioners.
+    Abstract base class of partitioners for numerical ranges.
     """
 
-    def __init__(
-        self,
-        max_partitions: int = None,
-    ) -> None:
-        """
-        :param max_partitions: the maximum number of partitions to make
-            (default: 20); should be at least 2
-        """
+    def __init__(self, max_partitions: Optional[int] = None) -> None:
+        """[see superclass]"""
+
         super().__init__(max_partitions)
 
         self._step: Optional[T_Values_Numeric] = None
@@ -409,7 +398,9 @@ class CategoryPartitioner(Partitioner[T_Values]):
 
     def __init__(self, max_partitions: Optional[int] = None) -> None:
         """[see superclass]"""
+
         super().__init__(max_partitions=max_partitions)
+
         self._frequencies = None
         self._partitions = None
 

--- a/src/facet/data/partition/_partition.py
+++ b/src/facet/data/partition/_partition.py
@@ -284,9 +284,9 @@ class RangePartitioner(
         # calculate the number of elements in each partitions
 
         # create the bins, starting with the lower bound of the first partition
-        partition_bins = (first_partition - step / 2) + np.arange(
-            n_partitions + 1
-        ) * step
+        partition_bins = (first_partition - step / 2) + (
+            step * np.arange(n_partitions + 1)
+        )
         partition_indices = np.digitize(values, bins=partition_bins)
 
         # frequency counts will include left and right outliers, hence n_partitions + 2

--- a/src/facet/data/partition/_partition.py
+++ b/src/facet/data/partition/_partition.py
@@ -55,10 +55,10 @@ class Partitioner(
 
     DEFAULT_MAX_PARTITIONS = 20
 
-    #: The central values for all partitions.
+    #: The values representing the partitions.
     _partitions: Optional[np.ndarray]
 
-    #: The value counts for all partitions.
+    #: The count of values allocated to each partition.
     _frequencies: Optional[np.ndarray]
 
     def __init__(self, max_partitions: Optional[int] = None) -> None:
@@ -90,7 +90,7 @@ class Partitioner(
     @property
     def partitions_(self) -> np.ndarray:
         """
-        The central values of all partitions.
+        The values representing the partitions.
         """
         self._ensure_fitted()
         return self._partitions
@@ -98,7 +98,7 @@ class Partitioner(
     @property
     def frequencies_(self) -> np.ndarray:
         """
-        The count of data points in each partition.
+        The count of values allocated to each partition.
         """
         self._ensure_fitted()
         return self._frequencies

--- a/src/facet/data/partition/_partition.py
+++ b/src/facet/data/partition/_partition.py
@@ -396,14 +396,6 @@ class CategoryPartitioner(Partitioner[T_Values]):
     :attr:`.max_partitions` most frequent values.
     """
 
-    def __init__(self, max_partitions: Optional[int] = None) -> None:
-        """[see superclass]"""
-
-        super().__init__(max_partitions=max_partitions)
-
-        self._frequencies = None
-        self._partitions = None
-
     @property
     def is_fitted(self) -> bool:
         """[see superclass]"""

--- a/test/test/facet/test_partition.py
+++ b/test/test/facet/test_partition.py
@@ -1,33 +1,142 @@
-from typing import Sequence
-
 import numpy as np
+import pytest
 
-from facet.data.partition import ContinuousRangePartitioner, IntegerRangePartitioner
+from facet.data.partition import (
+    CategoryPartitioner,
+    ContinuousRangePartitioner,
+    IntegerRangePartitioner,
+)
 
 
 def test_discrete_partitioning() -> None:
-    for i in range(0, 10000):
-        values: Sequence[int] = np.random.randint(
-            low=0, high=10000, size=max(int(np.random.rand() * 1000), 3)
+    np.random.seed(42)
+
+    for i in range(10):
+
+        values = np.random.randint(
+            low=0, high=10000, size=np.random.randint(low=100, high=200)
         )
-        # noinspection PyTypeChecker
+
         dvp = IntegerRangePartitioner(
             max_partitions=IntegerRangePartitioner.DEFAULT_MAX_PARTITIONS
         ).fit(values=values)
+
         # test correct number of partitions
         assert len(dvp.partitions_) <= IntegerRangePartitioner.DEFAULT_MAX_PARTITIONS
+        assert dvp.partition_bounds_ == [
+            (-500, 500),
+            (500, 1500),
+            (1500, 2500),
+            (2500, 3500),
+            (3500, 4500),
+            (4500, 5500),
+            (5500, 6500),
+            (6500, 7500),
+            (7500, 8500),
+            (8500, 9500),
+            (9500, 10500),
+        ]
+        assert (dvp.frequencies_ > 0).all()
+        assert (dvp.frequencies_ < 30).all()
+        assert dvp.frequencies_.sum() == len(values)
 
 
 def test_continuous_partitioning() -> None:
-    for i in range(0, 10000):
-        values = (
-            np.random.randint(
-                low=0, high=10000, size=max(int(np.random.rand() * 1000), 3)
-            )
-            * np.random.rand()
+    np.random.seed(42)
+
+    for i in range(10):
+
+        values = np.random.normal(
+            loc=3.0, scale=8.0, size=np.random.randint(low=2000, high=4000)
         )
+
         cvp = ContinuousRangePartitioner(
             max_partitions=ContinuousRangePartitioner.DEFAULT_MAX_PARTITIONS
         ).fit(values=values)
+
         # test correct number of partitions
         assert len(cvp.partitions_) <= ContinuousRangePartitioner.DEFAULT_MAX_PARTITIONS
+        partition_bounds_expected = [
+            (-22.5, -17.5),
+            (-17.5, -12.5),
+            (-12.5, -7.5),
+            (-7.5, -2.5),
+            (-2.5, 2.5),
+            (2.5, 7.5),
+            (7.5, 12.5),
+            (12.5, 17.5),
+            (17.5, 22.5),
+            (22.5, 27.5),
+        ]
+        assert (
+            cvp.partition_bounds_ == partition_bounds_expected
+            or cvp.partition_bounds_ == partition_bounds_expected[1:]
+            or cvp.partition_bounds_ == partition_bounds_expected[:-1]
+            or cvp.partition_bounds_ == partition_bounds_expected[1:-1]
+        )
+        assert cvp.frequencies_.sum() >= len(values) * 0.95
+
+
+def test_category_partitioning() -> None:
+    np.random.seed(42)
+    for i in range(10):
+        values = np.random.randint(
+            low=0, high=10, size=np.random.randint(low=100, high=200)
+        )
+        cp = CategoryPartitioner(max_partitions=4).fit(values=values)
+        # test correct number of partitions
+        assert len(cp.partitions_) == len(cp.frequencies_)
+        assert len(cp.partitions_) <= 4
+        assert len(cp.partitions_) == len(np.unique(cp.partitions_))
+        assert all(0 <= p <= 10 for p in cp.partitions_)
+        for p, f in zip(cp.partitions_, cp.frequencies_):
+            assert sum(values == p) == f
+
+
+def test_partition_with_invalid_values() -> None:
+
+    with pytest.raises(
+        ValueError,
+        match="arg values is empty",
+    ):
+        ContinuousRangePartitioner().fit([])
+
+    with pytest.raises(
+        ValueError,
+        match="insufficient variance in values; cannot infer partitioning bounds",
+    ):
+        ContinuousRangePartitioner().fit([1])
+
+    with pytest.raises(
+        ValueError,
+        match="insufficient variance in values; cannot infer partitioning bounds",
+    ):
+        ContinuousRangePartitioner().fit([1, 1, 1, 10, 1])
+
+    with pytest.raises(
+        ValueError,
+        match="arg values is empty",
+    ):
+        IntegerRangePartitioner().fit([])
+
+    with pytest.raises(
+        ValueError,
+        match="insufficient variance in values; cannot infer partitioning bounds",
+    ):
+        IntegerRangePartitioner().fit([1])
+
+    with pytest.raises(
+        ValueError,
+        match="insufficient variance in values; cannot infer partitioning bounds",
+    ):
+        IntegerRangePartitioner().fit([1, 1, 1, 10, 1])
+
+    with pytest.raises(
+        ValueError,
+        match="arg values is empty",
+    ):
+        CategoryPartitioner().fit([])
+
+    CategoryPartitioner().fit([1])
+
+    CategoryPartitioner().fit([1, 1, 1, 10, 1])


### PR DESCRIPTION
This PR makes args `lower_bound` and `upper_bound` an optional argument of `RangePartitioner.fit()`, instead of being `__init__` parameters.

Both arguments are better placed in the `fit` method because they may not be known at the time at which the `RangePartitioner` instance is created: they depend on the data the partitioner is fitted on, and are inferred by method `fit` if not specified.

This PR is needed to make PR #262 work.