### PR TITLE
FIX: change parameter used in if statement in _FitModelOnFullData

### DIFF
--- a/src/facet/crossfit/_crossfit.py
+++ b/src/facet/crossfit/_crossfit.py
@@ -579,7 +579,7 @@ class _FitModelOnFullData(_BaseFitAndScore):
         parameters = self.parameters
         pipeline = parameters.pipeline
 
-        if parameters.train_target is None:
+        if parameters.train_weight is None:
             pipeline.fit(
                 X=parameters.train_features,
                 y=parameters.train_target,


### PR DESCRIPTION
Hi @j-ittner!
While learning `facet` codebase I came across if statement in `_FitModelOnFullData` that looks off to me: We want to decide whether to pass `sample_weight=parameters.train_weight` but assertion is on `train_target` instead of `train_weight`. Is it expected to be this way?

Original PR: https://github.com/BCG-Gamma/facet/pull/276