### PR TITLE
API: support pytools 2.1 `@fitted_only` decorator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,5 +42,5 @@ repos:
         language_version: python39
         additional_dependencies:
           - numpy~=1.22
-          - gamma-pytools~=2.0,!=2.0.0
+          - gamma-pytools~=2.1rc
           - sklearndf~=2.0

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -75,6 +75,8 @@ Other
 
 - API: class ``LearnerCrossfit`` is no longer needed in FACET |nbsp| 2.0 and has been
   removed
+- API: support new :obj:`~pytools.fit.fitted_only` decorator introduced in *pytools*
+  |nbsp| 2.1.
 
 
 FACET 1.2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ stages:
               versionSpec: '3.9'
             displayName: 'use Python 3.9'
           - script: |
-              python -m pip install mypy~=0.971 numpy~=1.22 gamma-pytools~=2.0,!=2.0.0 sklearndf~=2.0
+              python -m pip install mypy~=0.971 numpy~=1.22 'gamma-pytools~=2.1|2.1rc' sklearndf~=2.0
               python -m mypy src
             displayName: 'Run mypy'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ stages:
               versionSpec: '3.9'
             displayName: 'use Python 3.9'
           - script: |
-              python -m pip install mypy~=0.971 numpy~=1.22 'gamma-pytools~=2.1|2.1rc' sklearndf~=2.0
+              python -m pip install mypy~=0.971 numpy~=1.22 'gamma-pytools~=2.1|~=2.1rc' sklearndf~=2.0
               python -m mypy src
             displayName: 'Run mypy'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ stages:
               versionSpec: '3.9'
             displayName: 'use Python 3.9'
           - script: |
-              python -m pip install mypy~=0.971 numpy~=1.22 'gamma-pytools~=2.1|~=2.1rc' sklearndf~=2.0
+              python -m pip install mypy~=0.971 numpy~=1.22 'gamma-pytools~=2.1rc' sklearndf~=2.0
               python -m mypy src
             displayName: 'Run mypy'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dist-name = "gamma-facet"
 license = "Apache Software License v2.0"
 
 requires = [
-    "gamma-pytools  ~=2.0",
+    "gamma-pytools  >=2.1rc,<3",
     "matplotlib     ~=3.0",
     "numpy          >=1.21,<2a",  # cannot use ~= due to conda bug
     "packaging      >=20",
@@ -74,7 +74,7 @@ no-binary.min = ["matplotlib", "shap"]
 
 [build.matrix.min]
 # direct requirements of gamma-facet
-gamma-pytools  = "~=2.0.4"
+gamma-pytools  = "~=2.1rc"
 matplotlib     = "~=3.0.3"
 numpy          = "==1.21.6"  # cannot use ~= due to conda bug
 packaging      = "~=20.9"
@@ -97,7 +97,7 @@ numba          = "~=0.55"  # required to support numpy 1.21
 
 [build.matrix.max]
 # direct requirements of gamma-facet
-gamma-pytools  = "~=2.0"
+gamma-pytools  = "~=2.1rc"
 matplotlib     = "~=3.5"
 numpy          = ">=1.22,<2a"  # cannot use ~= due to conda bug
 packaging      = ">=20"

--- a/src/facet/data/partition/_partition.py
+++ b/src/facet/data/partition/_partition.py
@@ -98,7 +98,7 @@ class Partitioner(
         """
         return self._max_partitions
 
-    @property
+    @property  # type: ignore
     @fitted_only
     def partitions_(self) -> Sequence[T_Values]:
         """
@@ -108,7 +108,7 @@ class Partitioner(
         assert self._partitions is not None, ASSERTION__PARTITIONER_IS_FITTED
         return self._partitions
 
-    @property
+    @property  # type: ignore
     @fitted_only
     def frequencies_(self) -> npt.NDArray[np.int_]:
         """
@@ -176,7 +176,7 @@ class RangePartitioner(
         """
         return False
 
-    @property
+    @property  # type: ignore
     @fitted_only
     def partition_bounds_(self) -> Sequence[Tuple[T_Values_Scalar, T_Values_Scalar]]:
         """
@@ -190,7 +190,7 @@ class RangePartitioner(
         assert self._partition_bounds is not None, ASSERTION__PARTITIONER_IS_FITTED
         return self._partition_bounds
 
-    @property
+    @property  # type: ignore
     @fitted_only
     def partition_width_(self) -> T_Values_Scalar:
         """

--- a/src/facet/data/partition/_partition.py
+++ b/src/facet/data/partition/_partition.py
@@ -13,6 +13,7 @@ import numpy.typing as npt
 
 from pytools.api import AllTracker, inheritdoc
 from pytools.fit import FittableMixin
+from pytools.fit._fit import fitted_only
 
 log = logging.getLogger(__name__)
 
@@ -99,22 +100,22 @@ class Partitioner(
         return self._max_partitions
 
     @property
+    @fitted_only
     def partitions_(self) -> Sequence[T_Values]:
         """
         The values representing the partitions.
         """
 
-        self.ensure_fitted()
         assert self._partitions is not None, ASSERTION__PARTITIONER_IS_FITTED
         return self._partitions
 
     @property
+    @fitted_only
     def frequencies_(self) -> npt.NDArray[np.int_]:
         """
         The count of values allocated to each partition.
         """
 
-        self.ensure_fitted()
         assert self._frequencies is not None, ASSERTION__PARTITIONER_IS_FITTED
         return self._frequencies
 
@@ -177,6 +178,7 @@ class RangePartitioner(
         return False
 
     @property
+    @fitted_only
     def partition_bounds_(self) -> Sequence[Tuple[T_Values_Scalar, T_Values_Scalar]]:
         """
         Return the endpoints of the intervals that delineate each partition.
@@ -186,17 +188,16 @@ class RangePartitioner(
             bound of a partition range
         """
 
-        self.ensure_fitted()
         assert self._partition_bounds is not None, ASSERTION__PARTITIONER_IS_FITTED
         return self._partition_bounds
 
     @property
+    @fitted_only
     def partition_width_(self) -> T_Values_Scalar:
         """
         The width of each partition.
         """
 
-        self.ensure_fitted()
         assert self._step is not None, ASSERTION__PARTITIONER_IS_FITTED
         return self._step
 

--- a/src/facet/data/partition/_partition.py
+++ b/src/facet/data/partition/_partition.py
@@ -12,8 +12,7 @@ import numpy as np
 import numpy.typing as npt
 
 from pytools.api import AllTracker, inheritdoc
-from pytools.fit import FittableMixin
-from pytools.fit._fit import fitted_only
+from pytools.fit import FittableMixin, fitted_only
 
 log = logging.getLogger(__name__)
 

--- a/src/facet/inspection/_learner_inspector.py
+++ b/src/facet/inspection/_learner_inspector.py
@@ -29,6 +29,7 @@ from sklearn.base import is_classifier
 from pytools.api import AllTracker, inheritdoc
 from pytools.data import LinkageTree, Matrix
 from pytools.fit import FittableMixin
+from pytools.fit._fit import fitted_only
 from pytools.parallelization import ParallelizableMixin
 from sklearndf import ClassifierDF, LearnerDF, RegressorDF
 from sklearndf.pipeline import LearnerPipelineDF
@@ -311,8 +312,8 @@ class LearnerInspector(
         return self
 
     @property
+    @fitted_only
     def _shap_global_explainer(self) -> ShapGlobalExplainer:
-        self.ensure_fitted()
         assert self._shap_global_projector is not None, ASSERTION__INSPECTOR_IS_FITTED
         return self._shap_global_projector
 
@@ -322,16 +323,17 @@ class LearnerInspector(
         return self._sample is not None
 
     @property
+    @fitted_only
     def sample_(self) -> Sample:
         """
         The background sample used to fit this inspector.
         """
 
-        self.ensure_fitted()
         assert self._sample is not None, ASSERTION__INSPECTOR_IS_FITTED
         return self._sample
 
     @property
+    @fitted_only
     def output_names_(self) -> Sequence[str]:
         """
         The names of the outputs explained by this inspector.
@@ -345,7 +347,6 @@ class LearnerInspector(
         For non-binary classifiers, this is the list of all classes.
         """
 
-        self.ensure_fitted()
         assert (
             self._shap_calculator is not None
             and self._shap_calculator.output_names_ is not None
@@ -353,6 +354,7 @@ class LearnerInspector(
         return self._shap_calculator.output_names_
 
     @property
+    @fitted_only
     def features_(self) -> List[str]:
         """
         The names of the features used to fit the learner pipeline explained by this
@@ -360,6 +362,7 @@ class LearnerInspector(
         """
         return cast(List[str], self.pipeline.feature_names_out_.to_list())
 
+    @fitted_only
     def shap_values(self) -> Union[pd.DataFrame, List[pd.DataFrame]]:
         """
         Calculate the SHAP values for all observations and features.
@@ -370,10 +373,10 @@ class LearnerInspector(
         :return: a data frame with SHAP values
         """
 
-        self.ensure_fitted()
         assert self._shap_calculator is not None, ASSERTION__INSPECTOR_IS_FITTED
         return self.__split_multi_output_df(self._shap_calculator.get_shap_values())
 
+    @fitted_only
     def shap_interaction_values(self) -> Union[pd.DataFrame, List[pd.DataFrame]]:
         """
         Calculate the SHAP interaction values for all observations and pairs of
@@ -385,11 +388,11 @@ class LearnerInspector(
 
         :return: a data frame with SHAP interaction values
         """
-        self.ensure_fitted()
         return self.__split_multi_output_df(
             self.__shap_interaction_values_calculator.get_shap_interaction_values()
         )
 
+    @fitted_only
     def feature_importance(
         self, *, method: str = "rms"
     ) -> Union[pd.Series, pd.DataFrame]:
@@ -407,8 +410,6 @@ class LearnerInspector(
         :return: a series of length `n_features` for single-output models, or a
             data frame of shape (n_features, n_outputs) for multi-output models
         """
-
-        self.ensure_fitted()
 
         methods = {"rms", "mav"}
         if method not in methods:
@@ -446,6 +447,7 @@ class LearnerInspector(
 
             return _normalize_importance(abs_importance.unstack(level=0))
 
+    @fitted_only
     def feature_synergy_matrix(
         self,
         *,
@@ -486,8 +488,6 @@ class LearnerInspector(
             `(n_features, n_features)`, or a list of data frames for multiple outputs
         """
 
-        self.ensure_fitted()
-
         return self.__feature_affinity_matrix(
             explainer_fn=self.__interaction_explainer.synergy,
             absolute=absolute,
@@ -495,6 +495,7 @@ class LearnerInspector(
             clustered=clustered,
         )
 
+    @fitted_only
     def feature_redundancy_matrix(
         self,
         *,
@@ -534,7 +535,6 @@ class LearnerInspector(
         :return: feature redundancy matrix as a data frame of shape
             `(n_features, n_features)`, or a list of data frames for multiple outputs
         """
-        self.ensure_fitted()
 
         return self.__feature_affinity_matrix(
             explainer_fn=self.__interaction_explainer.redundancy,
@@ -543,6 +543,7 @@ class LearnerInspector(
             clustered=clustered,
         )
 
+    @fitted_only
     def feature_association_matrix(
         self,
         *,
@@ -585,8 +586,6 @@ class LearnerInspector(
             `(n_features, n_features)`, or a list of data frames for multiple outputs
         """
 
-        self.ensure_fitted()
-
         return self.__feature_affinity_matrix(
             explainer_fn=self._shap_global_explainer.association,
             absolute=absolute,
@@ -594,6 +593,7 @@ class LearnerInspector(
             clustered=clustered,
         )
 
+    @fitted_only
     def feature_synergy_linkage(self) -> Union[LinkageTree, List[LinkageTree]]:
         """
         Calculate a linkage tree based on the :meth:`.feature_synergy_matrix`.
@@ -608,7 +608,6 @@ class LearnerInspector(
             for multi-target regressors or non-binary classifiers
         """
 
-        self.ensure_fitted()
         feature_affinity_matrix = self.__interaction_explainer.synergy(
             symmetrical=True, absolute=False
         )
@@ -620,6 +619,7 @@ class LearnerInspector(
             feature_affinity_matrix=feature_affinity_matrix
         )
 
+    @fitted_only
     def feature_redundancy_linkage(self) -> Union[LinkageTree, List[LinkageTree]]:
         """
         Calculate a linkage tree based on the :meth:`.feature_redundancy_matrix`.
@@ -634,7 +634,6 @@ class LearnerInspector(
             for multi-target regressors or non-binary classifiers
         """
 
-        self.ensure_fitted()
         feature_affinity_matrix = self.__interaction_explainer.redundancy(
             symmetrical=True, absolute=False
         )
@@ -646,6 +645,7 @@ class LearnerInspector(
             feature_affinity_matrix=feature_affinity_matrix
         )
 
+    @fitted_only
     def feature_association_linkage(self) -> Union[LinkageTree, List[LinkageTree]]:
         """
         Calculate a linkage tree based on the :meth:`.feature_association_matrix`.
@@ -660,7 +660,6 @@ class LearnerInspector(
             for multi-target regressors or non-binary classifiers
         """
 
-        self.ensure_fitted()
         feature_affinity_matrix = self._shap_global_explainer.association(
             absolute=False, symmetrical=True
         )
@@ -672,6 +671,7 @@ class LearnerInspector(
             feature_affinity_matrix=feature_affinity_matrix
         )
 
+    @fitted_only
     def feature_interaction_matrix(self) -> Union[FloatMatrix, List[FloatMatrix]]:
         """
         Calculate relative shap interaction values for all feature pairings.
@@ -777,6 +777,7 @@ class LearnerInspector(
             interaction_matrix, value_label="relative shap interaction"
         )
 
+    @fitted_only
     def shap_plot_data(self) -> ShapPlotData:
         """
         Consolidate SHAP values and corresponding feature values from this inspector

--- a/src/facet/inspection/_learner_inspector.py
+++ b/src/facet/inspection/_learner_inspector.py
@@ -311,7 +311,6 @@ class LearnerInspector(
         return self
 
     @property
-    @fitted_only
     def _shap_global_explainer(self) -> ShapGlobalExplainer:
         assert self._shap_global_projector is not None, ASSERTION__INSPECTOR_IS_FITTED
         return self._shap_global_projector
@@ -321,7 +320,7 @@ class LearnerInspector(
         """[see superclass]"""
         return self._sample is not None
 
-    @property
+    @property  # type: ignore
     @fitted_only
     def sample_(self) -> Sample:
         """
@@ -331,7 +330,7 @@ class LearnerInspector(
         assert self._sample is not None, ASSERTION__INSPECTOR_IS_FITTED
         return self._sample
 
-    @property
+    @property  # type: ignore
     @fitted_only
     def output_names_(self) -> Sequence[str]:
         """
@@ -352,7 +351,7 @@ class LearnerInspector(
         ), ASSERTION__INSPECTOR_IS_FITTED
         return self._shap_calculator.output_names_
 
-    @property
+    @property  # type: ignore
     @fitted_only
     def features_(self) -> List[str]:
         """

--- a/src/facet/inspection/_learner_inspector.py
+++ b/src/facet/inspection/_learner_inspector.py
@@ -28,8 +28,7 @@ from sklearn.base import is_classifier
 
 from pytools.api import AllTracker, inheritdoc
 from pytools.data import LinkageTree, Matrix
-from pytools.fit import FittableMixin
-from pytools.fit._fit import fitted_only
+from pytools.fit import FittableMixin, fitted_only
 from pytools.parallelization import ParallelizableMixin
 from sklearndf import ClassifierDF, LearnerDF, RegressorDF
 from sklearndf.pipeline import LearnerPipelineDF

--- a/src/facet/inspection/_shap.py
+++ b/src/facet/inspection/_shap.py
@@ -12,6 +12,7 @@ import pandas as pd
 
 from pytools.api import AllTracker, inheritdoc
 from pytools.fit import FittableMixin
+from pytools.fit._fit import fitted_only
 from pytools.parallelization import ParallelizableMixin
 from sklearndf.pipeline import (
     ClassifierPipelineDF,
@@ -336,9 +337,9 @@ class ShapValuesCalculator(
     Base class for calculating SHAP contribution values.
     """
 
+    @fitted_only
     def get_shap_values(self) -> pd.DataFrame:
         """[see superclass]"""
-        self.ensure_fitted()
         return self.shap_
 
     def get_shap_interaction_values(self) -> pd.DataFrame:
@@ -405,20 +406,21 @@ class ShapInteractionValuesCalculator(
     Base class for calculating SHAP interaction values.
     """
 
+    @fitted_only
     def get_shap_values(self) -> pd.DataFrame:
         """[see superclass]"""
 
-        self.ensure_fitted()
         assert self.shap_ is not None, ASSERTION__CALCULATOR_IS_FITTED
         return self.shap_.groupby(level=0).sum()
 
+    @fitted_only
     def get_shap_interaction_values(self) -> pd.DataFrame:
         """[see superclass]"""
 
-        self.ensure_fitted()
         assert self.shap_ is not None, ASSERTION__CALCULATOR_IS_FITTED
         return self.shap_
 
+    @fitted_only
     def get_diagonals(self) -> pd.DataFrame:
         """
         The get_diagonals of all SHAP interaction matrices, of shape
@@ -430,7 +432,6 @@ class ShapInteractionValuesCalculator(
             n_features * n_features.
         """
 
-        self.ensure_fitted()
         assert (
             self.shap_ is not None
             and self.sample_ is not None

--- a/src/facet/inspection/_shap.py
+++ b/src/facet/inspection/_shap.py
@@ -11,8 +11,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from pytools.api import AllTracker, inheritdoc
-from pytools.fit import FittableMixin
-from pytools.fit._fit import fitted_only
+from pytools.fit import FittableMixin, fitted_only
 from pytools.parallelization import ParallelizableMixin
 from sklearndf.pipeline import (
     ClassifierPipelineDF,

--- a/src/facet/inspection/_shap_projection.py
+++ b/src/facet/inspection/_shap_projection.py
@@ -11,6 +11,7 @@ import numpy as np
 import numpy.typing as npt
 
 from pytools.api import AllTracker, inheritdoc
+from pytools.fit._fit import fitted_only
 
 from ._shap import ShapCalculator
 from ._shap_global_explanation import (
@@ -66,10 +67,10 @@ class ShapProjector(ShapGlobalExplainer, metaclass=ABCMeta):
         super().__init__()
         self.association_: Optional[AffinityMatrix] = None
 
+    @fitted_only
     def association(self, absolute: bool, symmetrical: bool) -> npt.NDArray[np.float_]:
         """[see superclass]"""
 
-        self.ensure_fitted()
         assert self.association_ is not None
         return self.association_.get_values(symmetrical=symmetrical, absolute=absolute)
 
@@ -155,17 +156,17 @@ class ShapInteractionVectorProjector(ShapProjector, ShapInteractionGlobalExplain
         self.synergy_: Optional[AffinityMatrix] = None
         self.redundancy_: Optional[AffinityMatrix] = None
 
+    @fitted_only
     def synergy(self, symmetrical: bool, absolute: bool) -> npt.NDArray[np.float_]:
         """[see superclass]"""
 
-        self.ensure_fitted()
         assert self.synergy_ is not None, "Projector is fitted"
         return self.synergy_.get_values(symmetrical=symmetrical, absolute=absolute)
 
+    @fitted_only
     def redundancy(self, symmetrical: bool, absolute: bool) -> npt.NDArray[np.float_]:
         """[see superclass]"""
 
-        self.ensure_fitted()
         assert self.redundancy_ is not None, "Projector is fitted"
         return self.redundancy_.get_values(symmetrical=symmetrical, absolute=absolute)
 

--- a/src/facet/inspection/_shap_projection.py
+++ b/src/facet/inspection/_shap_projection.py
@@ -11,7 +11,7 @@ import numpy as np
 import numpy.typing as npt
 
 from pytools.api import AllTracker, inheritdoc
-from pytools.fit._fit import fitted_only
+from pytools.fit import fitted_only
 
 from ._shap import ShapCalculator
 from ._shap_global_explanation import (

--- a/src/facet/selection/_selection.py
+++ b/src/facet/selection/_selection.py
@@ -278,7 +278,7 @@ class LearnerSelector(
         """[see superclass]"""
         return self.searcher_ is not None
 
-    @property
+    @property  # type: ignore
     @fitted_only
     def best_estimator_(self) -> T_EstimatorDF:
         """

--- a/src/facet/selection/_selection.py
+++ b/src/facet/selection/_selection.py
@@ -30,6 +30,7 @@ from sklearn.model_selection import BaseCrossValidator, GridSearchCV
 
 from pytools.api import AllTracker, inheritdoc, to_list
 from pytools.fit import FittableMixin
+from pytools.fit._fit import fitted_only
 from pytools.parallelization import ParallelizableMixin
 from sklearndf import EstimatorDF
 from sklearndf.pipeline import LearnerPipelineDF
@@ -279,11 +280,11 @@ class LearnerSelector(
         return self.searcher_ is not None
 
     @property
+    @fitted_only
     def best_estimator_(self) -> T_EstimatorDF:
         """
         The model which obtained the best ranking score, fitted on the entire sample.
         """
-        self.ensure_fitted()
         searcher = self.searcher_
         assert searcher is not None, "Ranker is fitted"
 
@@ -350,6 +351,7 @@ class LearnerSelector(
 
         return self
 
+    @fitted_only
     def summary_report(self, *, sort_by: Optional[str] = None) -> pd.DataFrame:
         """
         Create a summary table of the scores achieved by all learners in the grid
@@ -360,8 +362,6 @@ class LearnerSelector(
 
         :return: the summary report of the grid search as a data frame
         """
-
-        self.ensure_fitted()
 
         if sort_by is None:
             sort_by = self._DEFAULT_REPORT_SORT_COLUMN

--- a/src/facet/selection/_selection.py
+++ b/src/facet/selection/_selection.py
@@ -29,8 +29,7 @@ from sklearn.metrics import get_scorer
 from sklearn.model_selection import BaseCrossValidator, GridSearchCV
 
 from pytools.api import AllTracker, inheritdoc, to_list
-from pytools.fit import FittableMixin
-from pytools.fit._fit import fitted_only
+from pytools.fit import FittableMixin, fitted_only
 from pytools.parallelization import ParallelizableMixin
 from sklearndf import EstimatorDF
 from sklearndf.pipeline import LearnerPipelineDF


### PR DESCRIPTION
Update the facet code to use pytools' new `@fitted_only` decorator instead of calling `ensure_fitted()` from inside methods and properties.

Note that *mypy* 0.971 reports an error for decorated properties; this will be fixed in *mypy* 0.980. Until this new version is released, we add `# type: ignore` comments to the affected `@property` declarations.