### PR TITLE
FIX: change flake8 repo link

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         name: flake8
         entry: flake8 --config tox.ini
         language: python_venv
-        additional_dependencies: [ flake8-comprehensions, flake8-import-order ]
+        additional_dependencies: [ flake8-comprehensions, flake8-import-order, importlib-metadata<5 ]
         types: [ python ]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: black
         language_version: python3
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.0
     hooks:
       - id: flake8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ stages:
               versionSpec: '3.7.*'
             displayName: 'use Python 3.7'
           - script: |
-              python -m pip install flake8==3.9.0 flake8-comprehensions flake8-import-order
+              python -m pip install flake8==3.9.0 flake8-comprehensions flake8-import-order importlib-metadata<5
               python -m flake8 --config tox.ini -v .
             displayName: 'Run flake8'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ stages:
               versionSpec: '3.7.*'
             displayName: 'use Python 3.7'
           - script: |
-              python -m pip install flake8==3.9.0 flake8-comprehensions flake8-import-order importlib-metadata<5
+              python -m pip install flake8==3.9.0 flake8-comprehensions flake8-import-order 'importlib-metadata<5'
               python -m flake8 --config tox.ini -v .
             displayName: 'Run flake8'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,6 +124,7 @@ stages:
     - job:
       displayName: 'pytest @ develop environment'
       condition: ne(variables.source_is_release_branch, 'True')
+      timeoutInMinutes: 60
 
       pool:
           vmImage: 'ubuntu-latest'

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: facet-develop_test
+name: facet-develop
 channels:
   - conda-forge
   - bcg_gamma

--- a/environment.yml
+++ b/environment.yml
@@ -1,46 +1,46 @@
-name: facet-develop
+name: facet-develop_test
 channels:
   - conda-forge
   - bcg_gamma
 dependencies:
   # run
   - boruta_py ~= 0.3
-  - gamma-pytools ~= 1.1.0
-  - joblib ~= 1.1
-  - lightgbm ~= 3.2
-  - matplotlib ~= 3.3
-  - numpy ~= 1.22.0
-  - pandas ~= 1.2
-  - python ~= 3.8.0
+  - gamma-pytools ~= 1.1.10, < 1.2a0
+  - joblib ~= 1.1.1
+  - lightgbm ~= 3.2.1
+  - matplotlib ~= 3.3.4
+  - numpy ~= 1.22.4
+  - pandas ~= 1.2.5
+  - python ~= 3.8.15
   - scikit-learn ~= 0.23.1
   - scipy ~= 1.5.3
   - shap ~= 0.39.0
-  - sklearndf ~= 1.1.0
+  - sklearndf ~= 1.1.3, < 1.2a
   # build/test
   - black = 20.8b1
   - conda-build ~= 3.21.8
   - conda-verify ~= 3.1.1
   - docutils ~= 0.16.0
   - flit ~= 3.0.0
-  - isort ~= 5.5
+  - isort ~= 5.11
   - jinja2 ~= 2.11
   - markupsafe < 2.1  # markupsafe 2.1 breaks support for jinja2
   - m2r ~= 0.2.0
-  - pluggy ~= 0.13
-  - pre-commit ~= 2.7
+  - pluggy ~= 0.13.1
+  - pre-commit ~= 2.21
   - pydata-sphinx-theme ~= 0.4.0
   - pytest ~= 5.2
-  - pytest-cov ~= 2.8
-  - pyyaml ~= 5.1
-  - sphinx ~= 3.4.0
-  - sphinx-autodoc-typehints ~= 1.11.0
-  - toml ~= 0.10.0
-  - tox ~= 3.20.0
-  - yaml ~= 0.2
+  - pytest-cov ~= 2.12
+  - pyyaml ~= 5.4
+  - sphinx ~= 3.4.3
+  - sphinx-autodoc-typehints ~= 1.11.1
+  - toml ~= 0.10.2
+  - tox ~= 3.27
+  - yaml ~= 0.2.5
   # notebooks
-  - jupyterlab ~= 3.1
+  - jupyterlab ~= 3.5.2
   - nbclassic ~= 0.2.8
   - nbsphinx ~= 0.7.0
-  - openpyxl ~= 3.0
-  - seaborn ~= 0.11.0
-  - tableone ~= 0.7.0
+  - openpyxl ~= 3.0.10
+  - seaborn ~= 0.11.2
+  - tableone ~= 0.7.10

--- a/environment.yml
+++ b/environment.yml
@@ -5,17 +5,17 @@ channels:
 dependencies:
   # run
   - boruta_py ~= 0.3
-  - gamma-pytools ~= 1.1
+  - gamma-pytools ~= 1.1.0
   - joblib ~= 1.1
   - lightgbm ~= 3.2
   - matplotlib ~= 3.3
-  - numpy ~= 1.22
+  - numpy ~= 1.22.0
   - pandas ~= 1.2
-  - python ~= 3.8
+  - python ~= 3.8.0
   - scikit-learn ~= 0.23.1
   - scipy ~= 1.5.3
   - shap ~= 0.39.0
-  - sklearndf ~= 1.1
+  - sklearndf ~= 1.1.0
   # build/test
   - black = 20.8b1
   - conda-build ~= 3.21.8


### PR DESCRIPTION
`flake8` is no longer available under https://gitlab.com/PyCQA/flake8 as the author made it private and moved to github instead https://github.com/PyCQA/flake8:

https://www.reddit.com/r/Python/comments/yvfww8/flake8_took_down_the_gitlab_repository_in_favor/
https://www.youtube.com/watch?v=1FIgj9Q5e6A

This should be merged upwards into `1.2.x` and `2.0.x`, as well in the other repositories.