### PR TITLE
FIX: remove contravariant from `T_Model`

### DIFF
--- a/src/facet/inspection/_explainer.py
+++ b/src/facet/inspection/_explainer.py
@@ -78,7 +78,7 @@ YType = Union[npt.NDArray[Any], pd.Series, None]
 # Type variables
 #
 
-T_Model = TypeVar("T_Model", bound=Union[Learner, ModelFunction])
+T_Model = TypeVar("T_Model")
 
 
 #
@@ -652,7 +652,9 @@ class TreeExplainerFactory(ExplainerFactory[Learner]):
 
 
 @inheritdoc(match="""[see superclass]""")
-class FunctionExplainerFactory(ExplainerFactory[ModelFunction], metaclass=ABCMeta):
+class FunctionExplainerFactory(
+    ExplainerFactory[Union[Learner, ModelFunction]], metaclass=ABCMeta
+):
     """
     A factory constructing :class:`~shap.Explainer` instances that use Python functions
     as the underlying model.
@@ -884,6 +886,7 @@ class _PermutationExplainer(
         """
         return False
 
+    # noinspection PyPep8Naming
     def shap_values(self, X: XType, y: YType = None, **kwargs: Any) -> ArraysFloat:
         # skip the call to super().shap_values() because would raise
         # an AttributeError exception due to a bug in the shap library

--- a/src/facet/inspection/_explainer.py
+++ b/src/facet/inspection/_explainer.py
@@ -32,6 +32,8 @@ from pytools.expression import Expression, HasExpressionRepr
 from pytools.expression.atomic import Id
 from pytools.parallelization import Job, JobQueue, JobRunner, ParallelizableMixin
 
+from ._types import ModelFunction
+
 log = logging.getLogger(__name__)
 
 __all__ = [
@@ -69,9 +71,6 @@ except ImportError:
 ArraysAny: TypeAlias = Union[npt.NDArray[Any], List[npt.NDArray[Any]]]
 ArraysFloat: TypeAlias = Union[npt.NDArray[np.float_], List[npt.NDArray[np.float_]]]
 Learner: TypeAlias = Union[RegressorMixin, ClassifierMixin]
-ModelFunction = Callable[
-    [Union[pd.Series, pd.DataFrame]], Union[float, np.ndarray, pd.Series]
-]
 XType = Union[npt.NDArray[Any], pd.DataFrame, catboost.Pool]
 YType = Union[npt.NDArray[Any], pd.Series, None]
 
@@ -79,9 +78,7 @@ YType = Union[npt.NDArray[Any], pd.Series, None]
 # Type variables
 #
 
-T_Model_contra = TypeVar(
-    "T_Model_contra", bound=Union[Learner, ModelFunction], contravariant=True
-)
+T_Model = TypeVar("T_Model", bound=Union[Learner, ModelFunction])
 
 
 #
@@ -198,7 +195,7 @@ class BaseExplainer(
             )
 
 
-class ExplainerFactory(HasExpressionRepr, Generic[T_Model_contra], metaclass=ABCMeta):
+class ExplainerFactory(HasExpressionRepr, Generic[T_Model], metaclass=ABCMeta):
     """
     A factory for constructing :class:`~shap.Explainer` objects.
     """
@@ -239,7 +236,7 @@ class ExplainerFactory(HasExpressionRepr, Generic[T_Model_contra], metaclass=ABC
 
     @abstractmethod
     def make_explainer(
-        self, model: T_Model_contra, data: Optional[pd.DataFrame]
+        self, model: T_Model, data: Optional[pd.DataFrame]
     ) -> BaseExplainer:
         """
         Construct a new :class:`~shap.Explainer` to compute shap values.

--- a/src/facet/inspection/_types.py
+++ b/src/facet/inspection/_types.py
@@ -5,10 +5,8 @@ Type aliases for common use in the inspection package
 from typing import Callable, Union
 
 import numpy as np
-import numpy.typing as npt
 import pandas as pd
 
 ModelFunction = Callable[
-    [Union[pd.DataFrame, npt.NDArray[np.float_]]],
-    Union[pd.Series, npt.NDArray[np.float_], float],
+    [Union[pd.Series, pd.DataFrame, np.ndarray]], Union[float, pd.Series, np.ndarray]
 ]

--- a/src/facet/inspection/_types.py
+++ b/src/facet/inspection/_types.py
@@ -5,8 +5,11 @@ Type aliases for common use in the inspection package
 from typing import Callable, Union
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
+# a function representing a model to be inspected
 ModelFunction = Callable[
-    [Union[pd.Series, pd.DataFrame, np.ndarray]], Union[float, pd.Series, np.ndarray]
+    [Union[pd.Series, pd.DataFrame, npt.NDArray[np.float_]]],
+    Union[pd.Series, npt.NDArray[np.float_], float],
 ]


### PR DESCRIPTION
Hi @j-ittner,

I'm in the middle of reviewing #352 and here I wanted to share a proposition of a minor change to typing.

I think that `contravariant=True` should be removed from `T_Model` in `_explainer.py` in `inspection` module, as in my opinion it isn't used in a contravariant setting. 

Classes that derive `ExplainerFactory` (`TreeExplainerFactory` and `FunctionExplainerFactory`) use all available bound types defined in `T_Model` -> `Learner` and `ModelFunction`.

The mypy errors, when dropping `contravariant=True`, come from the fact that **there are two slightly different type aliases with the same name** `ModelFunction` (one in `_explainer.py` and one in `_types.py`, where the latter misses `pd.Series` in the input type) used for the same purpose.

I unified them into one and removed `contravariant` parameter.



Let me know if I misunderstood it!