### PR TITLE
FIX: replace call to deprecated `Axes.get_text_heights()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 23.10.0
     hooks:
       - id: black
         language: python
@@ -41,6 +41,6 @@ repos:
         language: python
         language_version: python39
         additional_dependencies:
-          - numpy~=1.22
+          - numpy~=1.24
           - gamma-pytools~=2.1
           - sklearndf~=2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 23.10.0
+    rev: 23.10.1
     hooks:
       - id: black
         language: python

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -25,6 +25,8 @@ fully type-checked by |mypy|.
   and classifiers; it is no longer necessary to wrap them into a
   :class:`.RegressorPipelineDF` or :class:`.ClassifierPipelineDF` instance with empty
   preprocessing
+- FIX: replace a call to method ``get_text_heights()`` of :class:`matplotlib.axes.Axes`,
+  which is deprecated as of :mod:`matplotlib` |nbsp| 3.6
 
 
 2.0.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ stages:
               versionSpec: '3.9'
             displayName: 'use Python 3.9'
           - script: |
-              python -m pip install black~=22.8
+              python -m pip install black~=23.10.1
               python -m black --check .
             displayName: 'Run black'
       - job:

--- a/environment.yml
+++ b/environment.yml
@@ -5,17 +5,18 @@ channels:
 dependencies:
   # run
   - gamma-pytools     ~= 2.1
-  - joblib            ~= 1.2
+  - joblib            ~= 1.3
   - lightgbm          ~= 3.3
-  - matplotlib        ~= 3.7
-  - numpy             ~= 1.24
+  - matplotlib        ~= 3.8
+  - numpy             ~= 1.26
   - pandas            ~= 2.0
-  - python            ~= 3.9
-  - scikit-learn      ~= 1.2.0
-  - scipy             ~= 1.10
-  - shap              ~= 0.41
+  - python            ~= 3.11
+  - scikit-learn      ~= 1.2.2
+  - scipy             ~= 1.11
+  - shap              ~= 0.43
   - sklearndf         ~= 2.2
-  - typing_extensions ~= 4.3
+  - typing_extensions ~= 4.6
+  - xlrd              ~= 2.0
   # additional packages for notebooks etc.
   - pip     ~= 23.0
   - pip:
@@ -30,7 +31,7 @@ dependencies:
   - pydata-sphinx-theme      ~= 0.8.1
   # notebooks
   - ipywidgets ~= 8.0
-  - jupyterlab ~= 3.5
+  - jupyterlab ~= 4.0
   - openpyxl   ~= 3.0
   - seaborn    ~= 0.12
-  - tableone   ~= 0.7
+  - tableone   ~= 0.8


### PR DESCRIPTION
`matplotlib` 3.6 deprecates method `Axes.get_text_heights()`. This PR replaces a call to that method.