### PR TITLE
FIX: initialize ShapPlotData with preprocessed feature names

### DIFF
--- a/.idea/facet.iml
+++ b/.idea/facet.iml
@@ -15,7 +15,7 @@
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/sphinx/base" />
     </content>
-    <orderEntry type="jdk" jdkName="facet-base" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="facet-develop" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="sklearndf" />
     <orderEntry type="module" module-name="pytools" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="enabledOnReformat" value="true" />
+    <option name="enabledOnSave" value="true" />
+    <option name="executionMode" value="BINARY" />
+    <option name="pathToExecutable" value="/opt/homebrew/bin/black" />
+    <option name="sdkName" value="facet-develop" />
+  </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="facet-develop" project-jdk-type="Python SDK" />
   <component name="PyPackaging">
     <option name="earlyReleasesAsUpgrades" value="true" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -253,7 +253,7 @@ stages:
               # create and activate a build environment, then install the tools we need
               micromamba create -n build
               micromamba activate build
-              micromamba install -y -c conda-forge boa~=0.14 toml~=0.10 flit~=3.6 packaging~=20.9
+              micromamba install -y -c conda-forge rattler-build~=0.44 toml~=0.10 flit~=3.6 packaging~=20.9
             displayName: 'Install conda-build, flit, toml'
             condition: eq(variables['BUILD_SYSTEM'], 'conda')
 
@@ -352,7 +352,7 @@ stages:
               # create and activate a build environment, then install the tools we need
               micromamba create -n build
               micromamba activate build
-              micromamba install -y -c conda-forge boa~=0.14 toml~=0.10 flit~=3.6 packaging~=20.9
+              micromamba install -y -c conda-forge rattler-build~=0.44 toml~=0.10 flit~=3.6 packaging~=20.9
             displayName: 'Install conda-build, flit, toml'
             condition: eq(variables['BUILD_SYSTEM'], 'conda')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -225,7 +225,7 @@ stages:
               BUILD_SYSTEM: 'conda'
               PKG_DEPENDENCIES: 'max'
             minimum_dependencies_tox:
-              FACET_V_PYTHON_BUILD: '=3.7'
+              FACET_V_PYTHON_BUILD: '=3.9'
               BUILD_SYSTEM: 'tox'
               PKG_DEPENDENCIES: 'min'
             maximum_dependencies_tox:

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - python            ~= 3.11
   - scikit-learn      ~= 1.2.2
   - scipy             ~= 1.11
-  - shap              ~= 0.43
+  - shap              ~= 0.44.0
   - sklearndf         ~= 2.2
   - typing_extensions ~= 4.6
   - xlrd              ~= 2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires = [
     "packaging         >=20",
     "pandas            >=1.1",
     "scipy             ~=1.7",
-    "shap              >=0.39,<0.45", # todo: add support for breaking changes in v0.45
+    "shap              >=0.44,<0.45", # todo: add support for breaking changes in v0.45
     "scikit-learn      ~=1.0",
     "sklearndf         ~=2.2",
     "typing_extensions ~=4.0",
@@ -81,7 +81,7 @@ packaging         = "~=20.9"
 pandas            = "~=1.1.5"
 python            = ">=3.9.23,<3.10a"    # cannot use ~= due to conda bug
 scipy             = "~=1.7.3"
-shap              = "~=0.39.0"
+shap              = "~=0.44.0"
 sklearndf         = "~=2.2.0"
 typing_extensions = "~=4.0.0"
 # additional minimum requirements of sklearndf
@@ -94,7 +94,7 @@ joblib            = "~=1.0.0"
 typing_inspect    = "~=0.4.0"
 # additional minimum requirements of shap
 ipython           = "==7.0"
-numba             = "~=0.55.2"  # required to support numpy 1.21
+numba             = "~=0.58.1"  # required to support numpy 1.22
 
 [build.matrix.max]
 # direct requirements of gamma-facet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires = [
     "typing_extensions ~=4.0",
 ]
 
-requires-python = ">=3.7,<4a"
+requires-python = ">=3.9,<4a"
 
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -38,9 +38,10 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
 ]
 
@@ -48,7 +49,7 @@ classifiers = [
 testing = [
     "pytest ~= 7.1",
     "pytest-cov ~= 2.12",
-    "lightgbm ~=3.0.0",
+    "lightgbm ~=3.2",
     "xgboost ~= 1.5",
 ]
 docs = [
@@ -78,24 +79,22 @@ matplotlib        = "~=3.3.4"
 numpy             = "==1.21.6"  # cannot use ~= due to conda bug
 packaging         = "~=20.9"
 pandas            = "~=1.0.5"
-python            = ">=3.7.12,<3.8a"    # cannot use ~= due to conda bug
+python            = ">=3.9.23,<3.10a"    # cannot use ~= due to conda bug
 scipy             = "~=1.4.1"
 shap              = "~=0.39.0"
 sklearndf         = "~=2.2.0"
 typing_extensions = "~=4.0.0"
 # additional minimum requirements of sklearndf
 boruta            = "~=0.3.0"
-lightgbm          = "~=3.0.0"
+lightgbm          = "~=3.2.1"
 scikit-learn      = "~=1.0.2"
 xgboost           = "~=1.5.0"
 # additional minimum requirements of gamma-pytools
-joblib            = "~=0.14.1"
+joblib            = "~=1.0.0"
 typing_inspect    = "~=0.4.0"
 # additional minimum requirements of shap
 ipython           = "==7.0"
 numba             = "~=0.55.2"  # required to support numpy 1.21
-# additional requirements for testing
-zipp              = "<3.16"     # required to support python 3.7
 
 [build.matrix.max]
 # direct requirements of gamma-facet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ requires = [
     "matplotlib        ~=3.3",
     "numpy             >=1.21,<2a",  # cannot use ~= due to conda bug
     "packaging         >=20",
-    "pandas            >=1.0",
-    "scipy             ~=1.2",
+    "pandas            >=1.1",
+    "scipy             ~=1.7",
     "shap              >=0.39,<0.45", # todo: add support for breaking changes in v0.45
     "scikit-learn      ~=1.0",
     "sklearndf         ~=2.2",
@@ -78,9 +78,9 @@ gamma-pytools     = "~=2.1.0"
 matplotlib        = "~=3.3.4"
 numpy             = "==1.21.6"  # cannot use ~= due to conda bug
 packaging         = "~=20.9"
-pandas            = "~=1.0.5"
+pandas            = "~=1.1.5"
 python            = ">=3.9.23,<3.10a"    # cannot use ~= due to conda bug
-scipy             = "~=1.4.1"
+scipy             = "~=1.7.3"
 shap              = "~=0.39.0"
 sklearndf         = "~=2.2.0"
 typing_extensions = "~=4.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = "Apache Software License v2.0"
 requires = [
     "gamma-pytools     ~=2.1",
     "matplotlib        ~=3.3",
-    "numpy             >=1.21,<2a",  # cannot use ~= due to conda bug
+    "numpy             >=1.22,<2a",  # cannot use ~= due to conda bug
     "packaging         >=20",
     "pandas            >=1.1",
     "scipy             ~=1.7",
@@ -76,7 +76,7 @@ no-binary.min = ["matplotlib", "shap"]
 # direct requirements of gamma-facet
 gamma-pytools     = "~=2.1.0"
 matplotlib        = "~=3.3.4"
-numpy             = "==1.21.6"  # cannot use ~= due to conda bug
+numpy             = "==1.22.4"  # cannot use ~= due to conda bug
 packaging         = "~=20.9"
 pandas            = "~=1.1.5"
 python            = ">=3.9.23,<3.10a"    # cannot use ~= due to conda bug

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires = [
     "packaging         >=20",
     "pandas            >=1.0",
     "scipy             ~=1.2",
-    "shap              >=0.39",
+    "shap              >=0.39,<0.45", # todo: add support for breaking changes in v0.45
     "scikit-learn      ~=1.0",
     "sklearndf         ~=2.2",
     "typing_extensions ~=4.0",
@@ -106,7 +106,7 @@ packaging         = ">=20"
 pandas            = "~=2.0"
 python            = ">=3.9,<4a"   # cannot use ~= due to conda bug
 scipy             = "~=1.10"
-shap              = "~=0.41"
+shap              = "~=0.44.0" # todo: add support for breaking changes in v0.45
 sklearndf         = "~=2.2"
 typing_extensions = "~=4.3"
 # additional maximum requirements of sklearndf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = "Apache Software License v2.0"
 
 requires = [
     "gamma-pytools     ~=2.1",
-    "matplotlib        ~=3.0",
+    "matplotlib        ~=3.3",
     "numpy             >=1.21,<2a",  # cannot use ~= due to conda bug
     "packaging         >=20",
     "pandas            >=1.0",
@@ -74,7 +74,7 @@ no-binary.min = ["matplotlib", "shap"]
 [build.matrix.min]
 # direct requirements of gamma-facet
 gamma-pytools     = "~=2.1.0"
-matplotlib        = "~=3.0.3"
+matplotlib        = "~=3.3.4"
 numpy             = "==1.21.6"  # cannot use ~= due to conda bug
 packaging         = "~=20.9"
 pandas            = "~=1.0.5"
@@ -100,7 +100,7 @@ zipp              = "<3.16"     # required to support python 3.7
 [build.matrix.max]
 # direct requirements of gamma-facet
 gamma-pytools     = "~=2.1"
-matplotlib        = "~=3.6"
+matplotlib        = "~=3.9"
 numpy             = ">=1.23,<2a"  # cannot use ~= due to conda bug
 packaging         = ">=20"
 pandas            = "~=2.0"

--- a/src/facet/inspection/_inspection.py
+++ b/src/facet/inspection/_inspection.py
@@ -11,8 +11,6 @@ from typing_extensions import TypeAlias
 
 from pytools.api import AllTracker
 
-from ..data import Sample
-
 log = logging.getLogger(__name__)
 
 __all__ = [
@@ -46,15 +44,22 @@ class ShapPlotData:
     """
 
     def __init__(
-        self, shap_values: Union[FloatArray, List[FloatArray]], sample: Sample
+        self,
+        *,
+        shap_values: Union[FloatArray, List[FloatArray]],
+        features: pd.DataFrame,
+        target: Union[pd.Series, pd.DataFrame],
     ) -> None:
         """
         :param shap_values: the shap values for all observations and outputs
-        :param sample: (sub)sample of all observations for which SHAP values are
-            available; aligned with param ``shap_values``
+        :param features: features for which SHAP values are available;
+            aligned with param ``shap_values``
+        :param target: target values for all observations;
+            aligned with param ``shap_values``
         """
         self._shap_values = shap_values
-        self._sample = sample
+        self._features = features
+        self._target = target
 
     @property
     def shap_values(self) -> Union[FloatArray, List[FloatArray]]:
@@ -69,7 +74,7 @@ class ShapPlotData:
         """
         Matrix of feature values (number of observations by number of features).
         """
-        return self._sample.features
+        return self._features
 
     @property
     def target(self) -> Union[pd.Series, pd.DataFrame]:
@@ -78,7 +83,7 @@ class ShapPlotData:
         or matrix of target values for multi-output models
         (number of observations by number of outputs).
         """
-        return self._sample.target
+        return self._target
 
 
 __tracker.validate()

--- a/src/facet/inspection/base/_model_inspector.py
+++ b/src/facet/inspection/base/_model_inspector.py
@@ -736,7 +736,8 @@ class ModelInspector(
 
         return ShapPlotData(
             shap_values=shap_values_numpy,
-            sample=sample,
+            features=self.preprocess_features(sample.features),
+            target=sample.target,
         )
 
     @property

--- a/test/test/conftest.py
+++ b/test/test/conftest.py
@@ -453,7 +453,12 @@ def fit_classifier_selector(
     parameter_space = ParameterSpace(
         ClassifierPipelineDF(
             classifier=RandomForestClassifierDF(random_state=42),
-            preprocessing=None,
+            # this column transformer is a no-op, but we need it to
+            # run tests where preprocessing changes feature names
+            preprocessing=ColumnTransformerDF(
+                # we prefix all feature names with "pass__" except the last one
+                [("pass", "passthrough", sample.feature_names[:-1])]
+            ),
         )
     )
     parameter_space.classifier.n_estimators = [10, 50]

--- a/test/test/conftest.py
+++ b/test/test/conftest.py
@@ -457,7 +457,8 @@ def fit_classifier_selector(
             # run tests where preprocessing changes feature names
             preprocessing=ColumnTransformerDF(
                 # we prefix all feature names with "pass__" except the last one
-                [("pass", "passthrough", sample.feature_names[:-1])]
+                [("pass", "passthrough", sample.feature_names[:-1])],
+                remainder="passthrough",
             ),
         )
     )

--- a/test/test/facet/test_inspection.py
+++ b/test/test/facet/test_inspection.py
@@ -840,11 +840,20 @@ def test_shap_plot_data(
     assert all(shap.shape == features_shape for shap in shap_values)
 
     shap_index = shap_plot_data.features.index
+    preprocessing = iris_inspector_multi_class.model.preprocessing
+    assert preprocessing is not None, "preprocessing step must be defined"
+
     assert_frame_equal(
-        shap_plot_data.features, iris_sample_multi_class.features.loc[shap_index]
+        # the shap plot data should contain the same observations as the
+        # preprocessed features in the sample
+        shap_plot_data.features,
+        preprocessing.transform(iris_sample_multi_class.features).loc[shap_index],
     )
     assert_series_equal(
-        shap_plot_data.target, iris_sample_multi_class.target.loc[shap_index]
+        # the shap plot data should contain the same target values as the
+        # sample
+        shap_plot_data.target,
+        iris_sample_multi_class.target.loc[shap_index],
     )
 
 


### PR DESCRIPTION
This PR addresses a bug in relation to shap plot values: The `ShapPlotData` object returned by method `ModelInspector.shap_plot_data()` used the original feature set instead of the preprocessed feature set.

In cases where preprocessing changes the number or names of features, this led to a mismatch between the feature values and the shape values.
