### PR TITLE
FIX: allow parameters to override public fields of class ParameterSpace

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,6 +12,17 @@ FACET 2.2
 FACET 2.2 is a maintenance release to catch up with the latest versions of
 :mod:`gamma-pytools`. :mod:`sklearndf`, |shap|, and :mod:`numpy`.
 
+2.2.2
+~~~~~
+
+- FIX: Instances of :class:`.ParameterSpace` did not allow setting parameters whose
+  names clash with methods and properties of :class:`.ParameterSpace`.
+  To fix this, we renamed all methods and properties to include a trailing underscore.
+  The original methods and properties are still available but deprecated. They will be
+  removed in FACET 2.3, and estimator parameters with clashing names will override
+  the corresponding deprecated methods and properties of :class:`.ParameterSpace`.
+
+
 2.2.1
 ~~~~~
 

--- a/src/facet/selection/_parameters.py
+++ b/src/facet/selection/_parameters.py
@@ -7,12 +7,20 @@ from __future__ import annotations
 import logging
 import warnings
 from collections.abc import Collection, Iterable, Iterator
-from typing import Any, Generic, TypeAlias, TypeVar
+from typing import Any, Generic, TypeAlias, TypeVar, final
 
 from scipy import stats
 from sklearn.base import BaseEstimator
 
-from pytools.api import AllTracker, as_list, inheritdoc, subsdoc, validate_element_types
+from pytools.api import (
+    AllTracker,
+    appenddoc,
+    as_list,
+    deprecated,
+    inheritdoc,
+    subsdoc,
+    validate_element_types,
+)
 from pytools.expression import Expression, make_expression
 from pytools.expression.atomic import Id
 from sklearndf import EstimatorDF
@@ -50,7 +58,7 @@ except StopIteration:
 # Type variables
 #
 
-T_Estimator_co = TypeVar("T_Estimator_co", covariant=True, bound=EstimatorDF)
+T_Estimator_co = TypeVar("T_Estimator_co", covariant=True, bound=BaseEstimator)
 
 #
 # Ensure all symbols introduced below are included in __all__
@@ -133,7 +141,7 @@ distribution:
         self._values: ParameterDict = {}
         self._params: set[str] = set(params.keys())
 
-    def get_name(self) -> str:
+    def get_name_(self) -> str:
         """
         Get the name for this parameter space's estimator.
 
@@ -152,6 +160,17 @@ distribution:
         else:
             return self._name
 
+    @final
+    @deprecated(message="will be removed in v2.3.0; use 'get_name_' instead")
+    @appenddoc(to=get_name_, prepend=True)
+    def get_name(self) -> str:
+        """
+        .. warning::
+
+            Deprecated: will be removed in v2.3.0; use :meth:`.get_name_` instead.
+        """
+        return self.get_name_()
+
     @subsdoc(
         pattern="or a list of such dictionaries, ",
         replacement="",
@@ -159,9 +178,9 @@ distribution:
     @subsdoc(
         pattern="one or more dictionaries, each mapping",
         replacement="a dictionary mapping",
-        using=BaseParameterSpace.get_parameters,
+        using=BaseParameterSpace.get_parameters_,
     )
-    def get_parameters(self, prefix: str | None = None) -> ParameterDict:
+    def get_parameters_(self, prefix: str | None = None) -> ParameterDict:
         """[see superclass]"""
 
         return {
@@ -174,8 +193,7 @@ distribution:
     def _validate_parameter(self, name: str, value: ParameterSet) -> None:
         if name not in self._params:
             raise AttributeError(
-                f"unknown parameter name for "
-                f"{type(self.estimator).__name__}: {name}"
+                f"unknown parameter name for {type(self.estimator_).__name__}: {name}"
             )
 
         if not (
@@ -186,28 +204,24 @@ distribution:
             or callable(getattr(value, "rvs", None))
         ):
             raise TypeError(
-                f"expected list or distribution for parameter {name} but got: "
-                f"{value!r}"
+                f"expected list or distribution for parameter {name} but got: {value!r}"
             )
 
     def __setattr__(self, name: str, value: Any) -> None:
-        if name.startswith("_"):
+        if name.startswith("_") or name.endswith("_"):
             super().__setattr__(name, value)
         else:
             self._validate_parameter(name, value)
-            if name in self.__dict__:
-                warnings.warn(
-                    f"parameter {name!r} overrides {type(self).__name__}"
-                    f"attribute of same name",
-                    stacklevel=-1,
-                )
             self._values[name] = value
 
     def __dir__(self) -> Iterable[str]:
         return {*super().__dir__(), *self._params}
 
-    def __getattr__(self, key: str) -> Any:
-        if not key.startswith("_"):
+    def __getattribute__(self, key: str) -> Any:
+        if not (key.startswith("_") or key.endswith("_")):
+            # We have a public attribute access, without trailing underscore,
+            # so we first check if this refers to a child parameter space
+            # or a parameter value
             result: ParameterSpace[Any] | ParameterSet | None
 
             result = self._children.get(key, None)
@@ -218,6 +232,7 @@ distribution:
             if result is not None:
                 return result
 
+        # Fall back to normal attribute access
         return super().__getattribute__(key)
 
     def __iter__(self) -> Iterator[tuple[list[str], ParameterSet]]:
@@ -233,7 +248,7 @@ distribution:
         for name, child in self._children.items():
             yield from child._iter_parameters([*path_prefix, name])
 
-    def to_expression(self) -> Expression:
+    def to_expression_(self) -> Expression:
         """[see superclass]"""
         return self._to_expression([])
 
@@ -264,10 +279,10 @@ distribution:
 
         if path_prefix_list:
             return Id(type(self))(
-                **{".".join(path_prefix_list): self.estimator}, **parameters
+                **{".".join(path_prefix_list): self.estimator_}, **parameters
             )
         else:
-            return Id(type(self))(self.estimator, **parameters)
+            return Id(type(self))(self.estimator_, **parameters)
 
 
 @inheritdoc(match="""[see superclass]""")
@@ -308,9 +323,9 @@ class MultiEstimatorParameterSpace(
     @subsdoc(
         pattern="one or more dictionaries,",
         replacement="a list of dictionaries,",
-        using=BaseParameterSpace.get_parameters,
+        using=BaseParameterSpace.get_parameters_,
     )
-    def get_parameters(self, prefix: str | None = None) -> list[ParameterDict]:
+    def get_parameters_(self, prefix: str | None = None) -> list[ParameterDict]:
         """[see superclass]"""
         if prefix is None:
             prefix = ""
@@ -321,14 +336,14 @@ class MultiEstimatorParameterSpace(
 
         return [
             {
-                candidate_prefixed: [space.estimator],
-                prefix + CandidateEstimatorDF.PARAM_CANDIDATE_NAME: [space.get_name()],
-                **space.get_parameters(prefix=candidate_prefixed),
+                candidate_prefixed: [space.estimator_],
+                prefix + CandidateEstimatorDF.PARAM_CANDIDATE_NAME: [space.get_name_()],
+                **space.get_parameters_(prefix=candidate_prefixed),
             }
             for space in self.spaces
         ]
 
-    def to_expression(self) -> Expression:
+    def to_expression_(self) -> Expression:
         """[see superclass]"""
         # noinspection PyProtectedMember
         return Id(type(self))(*self.spaces)
@@ -367,7 +382,7 @@ def validate_spaces(spaces: Collection[ParameterSpace[T_Estimator_co]]) -> None:
     """
 
     estimator_types: set[str] = {
-        getattr(space.estimator, "_estimator_type") for space in spaces
+        getattr(space.estimator_, "_estimator_type") for space in spaces
     }
 
     if len(estimator_types) > 1:
@@ -392,9 +407,11 @@ def get_default_estimator_name(estimator: EstimatorDF) -> str:
 
     while True:
         if isinstance(estimator, CandidateEstimatorDF):
+            # noinspection PyUnresolvedReferences
             if estimator.candidate is None:
                 return type(estimator).__name__
             else:
+                # noinspection PyUnresolvedReferences
                 estimator = estimator.candidate
 
         elif isinstance(estimator, PipelineDF) and estimator.steps:

--- a/src/facet/selection/_selection.py
+++ b/src/facet/selection/_selection.py
@@ -275,6 +275,7 @@ class LearnerSelector(
             best_estimator = searcher.best_estimator_
             while isinstance(best_estimator, CandidateEstimatorDF):
                 # unpack the candidate estimator
+                # noinspection PyUnresolvedReferences
                 best_estimator = best_estimator.candidate
             return best_estimator
 
@@ -323,8 +324,8 @@ class LearnerSelector(
         parameter_space = self.parameter_space
         (searcher_type,) = self.searcher_type
         searcher = self.searcher_ = searcher_type(
-            parameter_space.estimator,
-            parameter_space.parameters,
+            parameter_space.estimator_,
+            parameter_space.parameters_,
             **self._get_searcher_parameters(),
         )
         if sample.weight is not None:
@@ -354,7 +355,7 @@ class LearnerSelector(
         # get the raw CV results
         cv_results: dict[str, Any] = self.searcher_.cv_results_
 
-        if isinstance(self.parameter_space.estimator, CandidateEstimatorDF):
+        if isinstance(self.parameter_space.estimator_, CandidateEstimatorDF):
             # our estimator is a candidate estimator, so we need to unpack the
             # candidate's parameter names
             cv_results = {
@@ -470,7 +471,7 @@ class LearnerSelector(
             # if scoring is not callable, it must be a string
             scorer = get_scorer(scoring)
 
-        # noinspection PyPep8Naming
+        # noinspection PyPep8Naming,PyUnresolvedReferences
         def _scorer_fn(
             estimator: EstimatorDF,
             X: pd.DataFrame,

--- a/src/facet/selection/base/_parameters.py
+++ b/src/facet/selection/base/_parameters.py
@@ -4,14 +4,14 @@ Core implementation of :mod:`facet.selection.base`
 
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, final
 
 import numpy.typing as npt
 import pandas as pd
 from scipy import stats
 
-from pytools.api import AllTracker, inheritdoc
-from pytools.expression import HasExpressionRepr
+from pytools.api import AllTracker, appenddoc, deprecated, inheritdoc
+from pytools.expression import Expression, HasExpressionRepr
 from sklearndf import ClassifierDF, EstimatorDF, RegressorDF, TransformerDF
 
 log = logging.getLogger(__name__)
@@ -36,7 +36,6 @@ ParameterDict = dict[str, list[Any] | stats.rv_continuous | stats.rv_discrete]
 T_CandidateEstimatorDF = TypeVar("T_CandidateEstimatorDF", bound="CandidateEstimatorDF")
 T_Estimator = TypeVar("T_Estimator", covariant=True, bound=EstimatorDF)
 
-
 #
 # Ensure all symbols introduced below are included in __all__
 #
@@ -49,6 +48,7 @@ __tracker = AllTracker(globals())
 #
 
 
+@inheritdoc(match="""[see superclass]""")
 class BaseParameterSpace(HasExpressionRepr, Generic[T_Estimator], metaclass=ABCMeta):
     """
     A collection of parameters spanning a parameter space for hyperparameter
@@ -64,14 +64,26 @@ class BaseParameterSpace(HasExpressionRepr, Generic[T_Estimator], metaclass=ABCM
         self._estimator = estimator
 
     @property
-    def estimator(self) -> T_Estimator:
+    def estimator_(self) -> T_Estimator:
         """
         The estimator associated with this parameter space.
         """
         return self._estimator
 
+    @final
     @property
-    def parameters(self) -> list[ParameterDict] | ParameterDict:
+    @deprecated(message="will be removed in v2.3.0; use 'estimator_' instead")
+    def estimator(self) -> T_Estimator:
+        """
+        .. warning::
+
+            Deprecated: will be removed in v2.3.0; use :attr:`.estimator_` instead.
+
+        """
+        return self.estimator_
+
+    @property
+    def parameters_(self) -> list[ParameterDict] | ParameterDict:
         """
         The parameter choices (as lists) or distributions (from :mod:`scipy.stats`)
         that constitute this parameter space.
@@ -79,10 +91,22 @@ class BaseParameterSpace(HasExpressionRepr, Generic[T_Estimator], metaclass=ABCM
         This is a shortcut for calling method :meth:`.get_parameters` with no
         arguments.
         """
-        return self.get_parameters()
+        return self.get_parameters_()
+
+    @final
+    @property
+    @deprecated(message="will be removed in v2.3.0; use 'parameters_' instead")
+    def parameters(self) -> list[ParameterDict] | ParameterDict:
+        """
+        .. warning::
+
+            Deprecated: will be removed in v2.3.0; use :attr:`.parameters_` instead.
+
+        """
+        return self.parameters_
 
     @abstractmethod
-    def get_parameters(
+    def get_parameters_(
         self, prefix: str | None = None
     ) -> list[ParameterDict] | ParameterDict:
         """
@@ -98,6 +122,36 @@ class BaseParameterSpace(HasExpressionRepr, Generic[T_Estimator], metaclass=ABCM
             choices (as lists) or distributions (from :mod:`scipy.stats`)
         """
         pass
+
+    @final
+    @deprecated(message="will be removed in v2.3.0; use 'get_parameters_' instead")
+    @appenddoc(to=get_parameters_, prepend=True)
+    def get_parameters(
+        self, prefix: str | None = None
+    ) -> list[ParameterDict] | ParameterDict:
+        """
+        .. warning::
+
+            Deprecated: will be removed in v2.3.0; use :meth:`.get_parameters_` instead.
+
+        """
+        return self.get_parameters_(prefix)
+
+    @final
+    def to_expression(self) -> Expression:
+        """[see superclass]"""
+        return self.to_expression_()
+
+    @abstractmethod
+    def to_expression_(self) -> Expression:
+        """
+        Create an expression representing this parameter space.
+
+        :return: an expression representing this parameter space
+        """
+
+    def __repr__(self) -> str:
+        return repr(self.to_expression_())
 
 
 @inheritdoc(match="""[see superclass]""")

--- a/test/test/facet/test_selection.py
+++ b/test/test/facet/test_selection.py
@@ -16,7 +16,11 @@ from sklearn.model_selection import GridSearchCV
 from pytools.expression import Expression, freeze
 from pytools.expression.atomic import Id
 from sklearndf import TransformerDF
-from sklearndf.classification import SVCDF, RandomForestClassifierDF
+from sklearndf.classification import (
+    SVCDF,
+    CalibratedClassifierCVDF,
+    RandomForestClassifierDF,
+)
 from sklearndf.pipeline import ClassifierPipelineDF, RegressorPipelineDF
 from sklearndf.regression import (
     AdaBoostRegressorDF,
@@ -298,9 +302,9 @@ def test_parameter_space(simple_preprocessor: TransformerDF) -> None:
         )
     )
 
-    assert mps.estimator.candidate is None
+    assert mps.estimator_.candidate is None
 
-    assert mps.parameters == [
+    assert mps.parameters_ == [
         {
             "candidate": [pipeline_1],
             "candidate_name": [ps_1_name],
@@ -333,6 +337,44 @@ def test_parameter_space(simple_preprocessor: TransformerDF) -> None:
             "my_prefix__candidate__regressor__min_child_samples": randint_1_32,
         },
     ]
+
+
+def test_parameter_space_attribute_overrides() -> None:
+    # check that reserved names can be overridden as parameters
+    classifier = CalibratedClassifierCVDF(SVCDF())
+    # noinspection PyTypeChecker
+    ps = ParameterSpace(classifier)
+
+    # calibrated classifier has an 'estimator' parameter
+    assert isinstance(ps.estimator, ParameterSpace)
+    ps.estimator.degree = [3, 4]
+    assert ps.estimator_ is classifier
+    assert ps.estimator.degree == [3, 4]
+
+    # but we don't override `estimator_`
+    assert ps.estimator_ is classifier
+
+    # we don't override `get_name` because it's not a parameter of the classifier
+    with pytest.deprecated_call(
+        match=(
+            r"^Call to deprecated function ParameterSpace.get_name: "
+            r"will be removed in v2.3.0; use 'get_name_' instead$"
+        )
+    ):
+        name = ps.get_name()
+    assert name == "CalibratedClassifierCVDF"
+
+    # and we don't override `parameters` because it's not a parameter of the classifier
+    assert ps.parameters_ == {"estimator__degree": [3, 4]}
+
+    # and we also have the new, non-deprecated `get_parameters_` method
+    with pytest.deprecated_call(
+        match=(
+            r"^Call to deprecated function BaseParameterSpace.parameters: "
+            r"will be removed in v2.3.0; use 'parameters_' instead$"
+        )
+    ):
+        assert ps.parameters == ps.parameters_
 
 
 def test_model_selector_regression(


### PR DESCRIPTION
This pull request fixes an issue with the parameter space API in the selection module, primarily to resolve naming conflicts between estimator parameters and internal methods/properties. All methods and properties of `ParameterSpace` that could clash with estimator parameter names have been renamed to have a trailing underscore (e.g., `estimator_`, `parameters_`, `get_parameters_`). The original names are now deprecated and will be removed in FACET 2.3. The update ensures that estimator parameters can safely override these names, and extensive deprecation warnings and documentation have been added. The changes also include updates to related classes, internal logic, and tests to support this new convention.

**API changes and deprecation (most important):**
* All methods and properties in `ParameterSpace` and related classes that could clash with estimator parameter names now have trailing underscores (e.g., `estimator_`, `parameters_`, `get_parameters_`). Deprecated versions without underscores are provided and will be removed in FACET 2.3. [[1]](diffhunk://#diff-d3b5a311ae3fc9b7c024837b3e2d851bb60b2fbc8a20113c003962183236a4deL67-R109) [[2]](diffhunk://#diff-d3b5a311ae3fc9b7c024837b3e2d851bb60b2fbc8a20113c003962183236a4deR126-R155) [[3]](diffhunk://#diff-aa714091548c4f4551399330a8ce87efb57a525713f8610d23497097cbdf2e8cL136-R144) [[4]](diffhunk://#diff-aa714091548c4f4551399330a8ce87efb57a525713f8610d23497097cbdf2e8cR163-R183) [[5]](diffhunk://#diff-aa714091548c4f4551399330a8ce87efb57a525713f8610d23497097cbdf2e8cL236-R251) [[6]](diffhunk://#diff-aa714091548c4f4551399330a8ce87efb57a525713f8610d23497097cbdf2e8cL311-R328) [[7]](diffhunk://#diff-aa714091548c4f4551399330a8ce87efb57a525713f8610d23497097cbdf2e8cL324-R346)
* The release notes (`RELEASE_NOTES.rst`) document this change and the deprecation plan, clarifying that estimator parameters with clashing names will override the deprecated methods/properties.

**Internal logic and compatibility:**
* All internal references to estimator and parameters have been updated to use the new trailing-underscore names for consistency and to avoid clashes. [[1]](diffhunk://#diff-d3b5a311ae3fc9b7c024837b3e2d851bb60b2fbc8a20113c003962183236a4deL67-R109) [[2]](diffhunk://#diff-aa714091548c4f4551399330a8ce87efb57a525713f8610d23497097cbdf2e8cL177-R196) [[3]](diffhunk://#diff-aa714091548c4f4551399330a8ce87efb57a525713f8610d23497097cbdf2e8cL267-R285) [[4]](diffhunk://#diff-aa714091548c4f4551399330a8ce87efb57a525713f8610d23497097cbdf2e8cL370-R385) [[5]](diffhunk://#diff-42387b5f891b74ae09b3f7eb659121e6cabc4170a3e20705c4eaf56d94be09c8L326-R328) [[6]](diffhunk://#diff-42387b5f891b74ae09b3f7eb659121e6cabc4170a3e20705c4eaf56d94be09c8L357-R358)
* The `TypeVar` for estimators in parameter space is now bound to `BaseEstimator` instead of `EstimatorDF` for broader compatibility.

**Testing and validation:**
* New tests have been added to verify that estimator parameters can override reserved names, and that deprecated methods/properties still function with appropriate warnings until removal. [[1]](diffhunk://#diff-5408238b1d71ad8663fe7cf0c17cd2719c8ec784d445ec4b799b08efc0beef0cR342-R379) [[2]](diffhunk://#diff-5408238b1d71ad8663fe7cf0c17cd2719c8ec784d445ec4b799b08efc0beef0cL301-R307)
* Existing tests and usages have been refactored to use the new trailing-underscore API.

**Documentation and warnings:**
* Extensive deprecation warnings and documentation have been added to all affected methods and properties, guiding users to migrate to the new API and informing them of the removal timeline. [[1]](diffhunk://#diff-d3b5a311ae3fc9b7c024837b3e2d851bb60b2fbc8a20113c003962183236a4deL67-R109) [[2]](diffhunk://#diff-d3b5a311ae3fc9b7c024837b3e2d851bb60b2fbc8a20113c003962183236a4deR126-R155) [[3]](diffhunk://#diff-aa714091548c4f4551399330a8ce87efb57a525713f8610d23497097cbdf2e8cR163-R183)

**Minor fixes and improvements:**
* Minor code cleanups, such as improved `noinspection` comments and import adjustments, are included for clarity and maintainability. [[1]](diffhunk://#diff-aa714091548c4f4551399330a8ce87efb57a525713f8610d23497097cbdf2e8cR410-R414) [[2]](diffhunk://#diff-42387b5f891b74ae09b3f7eb659121e6cabc4170a3e20705c4eaf56d94be09c8R278) [[3]](diffhunk://#diff-42387b5f891b74ae09b3f7eb659121e6cabc4170a3e20705c4eaf56d94be09c8L473-R474) [[4]](diffhunk://#diff-aa714091548c4f4551399330a8ce87efb57a525713f8610d23497097cbdf2e8cL10-R23) [[5]](diffhunk://#diff-d3b5a311ae3fc9b7c024837b3e2d851bb60b2fbc8a20113c003962183236a4deL7-R14) [[6]](diffhunk://#diff-d3b5a311ae3fc9b7c024837b3e2d851bb60b2fbc8a20113c003962183236a4deL39)

These changes ensure that the parameter space API is robust against naming conflicts and provide a clear migration path for users.